### PR TITLE
Route name in RouteResult is route path not name

### DIFF
--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -216,26 +216,31 @@ class FastRouteRouter implements RouterInterface
      */
     private function marshalMatchedRoute(array $result, $method)
     {
-        $path       = $result[1];
-        $middleware = array_reduce($this->routes, function ($middleware, $route) use ($path, $method) {
-            if ($middleware) {
-                return $middleware;
+        $path  = $result[1];
+        $route = array_reduce($this->routes, function ($matched, $route) use ($path, $method) {
+            if ($matched) {
+                return $matched;
             }
 
             if ($path !== $route->getPath()) {
-                return $middleware;
+                return $matched;
             }
 
             if (! $route->allowsMethod($method)) {
-                return $middleware;
+                return $matched;
             }
 
-            return $route->getMiddleware();
+            return $route;
         }, false);
 
+        if (false === $route) {
+            // This likely should never occur, but is present for completeness.
+            return RouteResult::fromRouteFailure();
+        }
+
         return RouteResult::fromRouteMatch(
-            $path,
-            $middleware,
+            $route->getName(),
+            $route->getMiddleware(),
             $result[2]
         );
     }


### PR DESCRIPTION
Looking at the `RouteResult` in the `psrRequest` shows the route path such as `/customer/create` as the `matchedRouteName` rather than `customer.create` which is what is specified in the route configuration as such:

``` php
[
    'name' => 'customer.create',
    'path' => '/customer/create',
    'middleware' =>  App\Action\CreateCustomer::class,
    'allowed_methods' => ['POST'],
],
```

I'm not sure if this is the intention or not. If it isn't a bug like I suspect it is, what is the purpose of the name then?

The specific line is https://github.com/zendframework/zend-expressive-fastroute/blob/master/src/FastRouteRouter.php#L236
