### PR TITLE
handles optional segments in uri generation

### DIFF
--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -14,7 +14,7 @@ use FastRoute\Dispatcher\GroupCountBased as Dispatcher;
 use FastRoute\RouteCollector;
 use FastRoute\RouteParser\Std as RouteParser;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Zend\Expressive\Exception;
+use Zend\Expressive\Router\Exception;
 
 /**
  * Router implementation bridging nikic/fast-route.

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -156,8 +156,7 @@ class FastRouteRouter implements RouterInterface
                 unset($segs[$n]);
             }
         }
-        $segs = array_reverse($segs);
-        $path = implode('', $segs);
+        $path = implode('', array_reverse($segs));
 
         return $path;
     }

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -152,7 +152,13 @@ class FastRouteRouter implements RouterInterface
         $path = str_replace(']', '', $path);
         $segs = array_reverse(explode('[', $path));
         foreach ($segs as $n => $seg) {
-            if (strpos($seg, '{') !== false && ! isset($segs[$n - 1])) {
+            if (strpos($seg, '{') !== false) {
+                if (isset($segs[$n - 1])) {
+                    throw new Exception\InvalidArgumentException(
+                        'Optional segments with unsubstituted parameters cannot'
+                        . ' contain segments with substituted parameters'
+                    );
+                }
                 unset($segs[$n]);
             }
         }

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -146,6 +146,19 @@ class FastRouteRouter implements RouterInterface
             $path = preg_replace($pattern, $value, $path);
         }
 
+        // 1. remove optional segments' ending delimiters
+        // 2. split path into an array of optional segments and remove those
+        // containing unsubstituted parameters starting from the last segment
+        $path = str_replace(']', '', $path);
+        $segs = array_reverse(explode('[', $path));
+        foreach ($segs as $n => $seg) {
+            if (strpos($seg, '{') !== false && ! isset($segs[$n - 1])) {
+                unset($segs[$n]);
+            }
+        }
+        $segs = array_reverse($segs);
+        $path = implode('', $segs);
+
         return $path;
     }
 

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -225,7 +225,7 @@ class FastRouteRouterTest extends TestCase
         $route3 = new Route('/foo/{id:\d+}', 'foo', ['GET'], 'foo');
         $route4 = new Route('/bar/{baz}', 'bar', Route::HTTP_METHOD_ANY, 'bar');
         $route5 = new Route('/index[/{page:\d+}]', 'foo', ['GET'], 'index');
-        $route6 = new Route('/extra[/{page:\d+}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra');        
+        $route6 = new Route('/extra[/{page:\d+}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra');
 
         $router->addRoute($route1);
         $router->addRoute($route2);

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -224,16 +224,27 @@ class FastRouteRouterTest extends TestCase
         $route2 = new Route('/foo', 'foo', ['GET'], 'foo-list');
         $route3 = new Route('/foo/{id:\d+}', 'foo', ['GET'], 'foo');
         $route4 = new Route('/bar/{baz}', 'bar', Route::HTTP_METHOD_ANY, 'bar');
+        $route5 = new Route('/index[/{page:\d+}]', 'foo', ['GET'], 'index');
+        $route6 = new Route('/extra[/{page:\d+}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra');        
 
         $router->addRoute($route1);
         $router->addRoute($route2);
         $router->addRoute($route3);
         $router->addRoute($route4);
+        $router->addRoute($route5);
+        $router->addRoute($route6);
 
         $this->assertEquals('/foo', $router->generateUri('foo-create'));
         $this->assertEquals('/foo', $router->generateUri('foo-list'));
         $this->assertEquals('/foo/42', $router->generateUri('foo', ['id' => 42]));
         $this->assertEquals('/bar/BAZ', $router->generateUri('bar', ['baz' => 'BAZ']));
+        $this->assertEquals('/index', $router->generateUri('index'));
+        $this->assertEquals('/index/42', $router->generateUri('index', ['page' => 42]));
+        $this->assertEquals('/extra/42', $router->generateUri('extra', ['page' => 42]));
+        $this->assertEquals('/extra/42/optional-segment', $router->generateUri('extra', [
+            'page'  => 42,
+            'extra' => 'segment'
+        ]));
     }
 
     public function testReturnedRouteResultShouldContainRouteName()

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -274,4 +274,18 @@ class FastRouteRouterTest extends TestCase
         $this->assertTrue($result->isSuccess());
         $this->assertEquals('foo-route', $result->getMatchedRouteName());
     }
+
+    /**
+     * @expectedException \Zend\Expressive\Router\Exception\InvalidArgumentException
+     */
+    public function testExceptionForUncompleteUriSubstitutions()
+    {
+        $router = new FastRouteRouter();
+
+        $route = new Route('/foo[/{param}[/optional-{extra}]]', 'foo', ['GET'], 'foo');
+
+        $router->addRoute($route);
+
+        $router->generateUri('foo', ['extra' => 'segment']);
+    }
 }


### PR DESCRIPTION
Quick fix to handle routes defined with path like:

``` php
//...
'name' => 'blog/post',
'path' => '/blog/post[/{action:index|recent}[/{page:\d+}[/optional-{extra}]]]',
//...
```

``` php
$urlHelper('blog/post');

// assume that current matching route has action=index and page=3

// w/o fix  => blog/post[/index[/3[/optional-{extra}]]]  
// with fix => blog/post/index/3
```
- TODO: add unit test case ***DONE
- ALT: use slim-3 method (leveraging fastroute std route parser) for uri generation? ***NO
- throw exception if substituted optional segment lives inside an unsubstituted optional segment? ***DONE
- use regex for argument matching instead of strpos? (strpos is faster and should be enough to match opening curly brackets for acceptable fast-route paths)
