### PR TITLE
Update dependency of FastRoute to 0.7.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 1.0.2 - TBD
+## 1.1.0 - TBD
 
 ### Added
 
-- Nothing.
+- [#4] FastRoute minimum version has been bumped to 0.7.*. No BC break is expected by this change, but you may
+want to make sure to test your application to confirm it.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- [#4] FastRoute minimum version has been bumped to 0.7.*. No BC break is expected by this change, but you may
+- [#4] FastRoute minimum version has been bumped to ~0.7.0. No BC break is expected by this change, but you may
 want to make sure to test your application to confirm it.
 
 ### Deprecated

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
-        "nikic/fast-route": "^0.6.0",
+        "nikic/fast-route": "^0.7.0",
         "psr/http-message": "^1.0",
         "zendframework/zend-expressive-router": "^1.0"
     },


### PR DESCRIPTION
I was unsure if this should do a 1.0.2 or 1.1.0, but as we have an upgrade to the main dependency (although, after checking the changelog of FastRoute, the bump on their side is due to an increased minimum version of HHVM).

I let you decide what do to @weierophinney :).
