### PR TITLE
Enchance pattern to match character limit regex

### DIFF
--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -142,7 +142,7 @@ class FastRouteRouter implements RouterInterface
         $path  = $route->getPath();
 
         foreach ($substitutions as $key => $value) {
-            $pattern = sprintf('#\{%s(:[^}]+)?\}#', preg_quote($key));
+            $pattern = sprintf('#\{%s(:[^}]+)?\}}#', preg_quote($key));
             $path = preg_replace($pattern, $value, $path);
         }
 

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -250,7 +250,7 @@ class FastRouteRouterTest extends TestCase
         ]));
         $this->assertEquals('/extra/2/optional-segment', $router->generateUri('limit', [
             'page'  => 2,
-            'limit' => 'segment'
+            'extra' => 'segment'
         ]));
     }
 

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -244,11 +244,11 @@ class FastRouteRouterTest extends TestCase
         $this->assertEquals('/index', $router->generateUri('index'));
         $this->assertEquals('/index/42', $router->generateUri('index', ['page' => 42]));
         $this->assertEquals('/extra/42', $router->generateUri('extra', ['page' => 42]));
-        $this->assertEquals('/limit/42/optional-segment', $router->generateUri('extra', [
+        $this->assertEquals('/extra/42/optional-segment', $router->generateUri('extra', [
             'page'  => 42,
             'extra' => 'segment'
         ]));
-        $this->assertEquals('/extra/2/optional-segment', $router->generateUri('limit', [
+        $this->assertEquals('/limit/2/optional-segment', $router->generateUri('limit', [
             'page'  => 2,
             'extra' => 'segment'
         ]));

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -227,7 +227,7 @@ class FastRouteRouterTest extends TestCase
         $route4 = new Route('/bar/{baz}', 'bar', Route::HTTP_METHOD_ANY, 'bar');
         $route5 = new Route('/index[/{page:\d+}]', 'foo', ['GET'], 'index');
         $route6 = new Route('/extra[/{page:\d+}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra');
-        $route7 = new Route('/extra[/{page:\d+}/{locale:[a-z]{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'limit');
+        $route7 = new Route('/page[/{page:\d+}/{locale:[a-z]{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'limit');
 
         $router->addRoute($route1);
         $router->addRoute($route2);
@@ -248,7 +248,7 @@ class FastRouteRouterTest extends TestCase
             'page'  => 42,
             'extra' => 'segment'
         ]));
-        $this->assertEquals('/extra/42/en/optional-segment', $router->generateUri('limit', [
+        $this->assertEquals('/page/42/en/optional-segment', $router->generateUri('limit', [
             'locale'=> 'en',
             'page'  => 2,
             'extra' => 'segment'

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -227,7 +227,7 @@ class FastRouteRouterTest extends TestCase
         $route4 = new Route('/bar/{baz}', 'bar', Route::HTTP_METHOD_ANY, 'bar');
         $route5 = new Route('/index[/{page:\d+}]', 'foo', ['GET'], 'index');
         $route6 = new Route('/extra[/{page:\d+}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra');
-        $route7 = new Route('/limit[/{page:\d+{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'limit');
+        $route7 = new Route('/extra[/{page:\d{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra');
 
         $router->addRoute($route1);
         $router->addRoute($route2);
@@ -248,7 +248,7 @@ class FastRouteRouterTest extends TestCase
             'page'  => 42,
             'extra' => 'segment'
         ]));
-        $this->assertEquals('/limit/2/optional-segment', $router->generateUri('limit', [
+        $this->assertEquals('/extra/2/optional-segment', $router->generateUri('extra', [
             'page'  => 2,
             'extra' => 'segment'
         ]));
@@ -292,4 +292,3 @@ class FastRouteRouterTest extends TestCase
         $router->generateUri('foo', ['extra' => 'segment']);
     }
 }
-

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -227,7 +227,7 @@ class FastRouteRouterTest extends TestCase
         $route4 = new Route('/bar/{baz}', 'bar', Route::HTTP_METHOD_ANY, 'bar');
         $route5 = new Route('/index[/{page:\d+}]', 'foo', ['GET'], 'index');
         $route6 = new Route('/extra[/{page:\d+}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra');
-        $route7 = new Route('/extra[/{page:\d{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra');
+        $route7 = new Route('/extra[/{page:\d{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'limit');
 
         $router->addRoute($route1);
         $router->addRoute($route2);
@@ -248,7 +248,7 @@ class FastRouteRouterTest extends TestCase
             'page'  => 42,
             'extra' => 'segment'
         ]));
-        $this->assertEquals('/extra/2/optional-segment', $router->generateUri('extra', [
+        $this->assertEquals('/extra/2/optional-segment', $router->generateUri('limit', [
             'page'  => 2,
             'extra' => 'segment'
         ]));

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -227,7 +227,7 @@ class FastRouteRouterTest extends TestCase
         $route4 = new Route('/bar/{baz}', 'bar', Route::HTTP_METHOD_ANY, 'bar');
         $route5 = new Route('/index[/{page:\d+}]', 'foo', ['GET'], 'index');
         $route6 = new Route('/extra[/{page:\d+}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra');
-        $route7 = new Route('/extra[/{page:\d{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'limit');
+        $route7 = new Route('/extra[/{page:\d+}/{locale:[a-z]{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'limit');
 
         $router->addRoute($route1);
         $router->addRoute($route2);
@@ -248,7 +248,8 @@ class FastRouteRouterTest extends TestCase
             'page'  => 42,
             'extra' => 'segment'
         ]));
-        $this->assertEquals('/extra/2/optional-segment', $router->generateUri('limit', [
+        $this->assertEquals('/extra/42/en/optional-segment', $router->generateUri('limit', [
+            'locale'=> 'en',
             'page'  => 2,
             'extra' => 'segment'
         ]));

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -227,6 +227,7 @@ class FastRouteRouterTest extends TestCase
         $route4 = new Route('/bar/{baz}', 'bar', Route::HTTP_METHOD_ANY, 'bar');
         $route5 = new Route('/index[/{page:\d+}]', 'foo', ['GET'], 'index');
         $route6 = new Route('/extra[/{page:\d+}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra');
+        $route7 = new Route('/extra[/{page:\d+{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra');
 
         $router->addRoute($route1);
         $router->addRoute($route2);
@@ -234,6 +235,7 @@ class FastRouteRouterTest extends TestCase
         $router->addRoute($route4);
         $router->addRoute($route5);
         $router->addRoute($route6);
+        $router->addRoute($route7);
 
         $this->assertEquals('/foo', $router->generateUri('foo-create'));
         $this->assertEquals('/foo', $router->generateUri('foo-list'));
@@ -244,6 +246,10 @@ class FastRouteRouterTest extends TestCase
         $this->assertEquals('/extra/42', $router->generateUri('extra', ['page' => 42]));
         $this->assertEquals('/extra/42/optional-segment', $router->generateUri('extra', [
             'page'  => 42,
+            'extra' => 'segment'
+        ]));
+        $this->assertEquals('/extra/2/optional-segment', $router->generateUri('extra', [
+            'page'  => 2,
             'extra' => 'segment'
         ]));
     }
@@ -286,3 +292,4 @@ class FastRouteRouterTest extends TestCase
         $router->generateUri('foo', ['extra' => 'segment']);
     }
 }
+

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -227,7 +227,7 @@ class FastRouteRouterTest extends TestCase
         $route4 = new Route('/bar/{baz}', 'bar', Route::HTTP_METHOD_ANY, 'bar');
         $route5 = new Route('/index[/{page:\d+}]', 'foo', ['GET'], 'index');
         $route6 = new Route('/extra[/{page:\d+}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra');
-        $route7 = new Route('/extra[/{page:\d+{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra');
+        $route7 = new Route('/extra[/{page:\d+{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'limit');
 
         $router->addRoute($route1);
         $router->addRoute($route2);
@@ -248,7 +248,7 @@ class FastRouteRouterTest extends TestCase
             'page'  => 42,
             'extra' => 'segment'
         ]));
-        $this->assertEquals('/extra/2/optional-segment', $router->generateUri('extra', [
+        $this->assertEquals('/extra/2/optional-segment', $router->generateUri('limit', [
             'page'  => 2,
             'extra' => 'segment'
         ]));

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -227,7 +227,7 @@ class FastRouteRouterTest extends TestCase
         $route4 = new Route('/bar/{baz}', 'bar', Route::HTTP_METHOD_ANY, 'bar');
         $route5 = new Route('/index[/{page:\d+}]', 'foo', ['GET'], 'index');
         $route6 = new Route('/extra[/{page:\d+}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra');
-        $route7 = new Route('/extra[/{page:\d+{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'limit');
+        $route7 = new Route('/limit[/{page:\d+{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'limit');
 
         $router->addRoute($route1);
         $router->addRoute($route2);
@@ -244,7 +244,7 @@ class FastRouteRouterTest extends TestCase
         $this->assertEquals('/index', $router->generateUri('index'));
         $this->assertEquals('/index/42', $router->generateUri('index', ['page' => 42]));
         $this->assertEquals('/extra/42', $router->generateUri('extra', ['page' => 42]));
-        $this->assertEquals('/extra/42/optional-segment', $router->generateUri('extra', [
+        $this->assertEquals('/limit/42/optional-segment', $router->generateUri('extra', [
             'page'  => 42,
             'extra' => 'segment'
         ]));

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -250,7 +250,7 @@ class FastRouteRouterTest extends TestCase
         ]));
         $this->assertEquals('/extra/2/optional-segment', $router->generateUri('limit', [
             'page'  => 2,
-            'extra' => 'segment'
+            'limit' => 'segment'
         ]));
     }
 


### PR DESCRIPTION
For example to giving this route

``` php
'routes' => [
        [
            'name' => 'home',
            'path' => '/{locale:[a-z]{2}}',
            'middleware' => App\Action\HomePageAction::class,
            'allowed_methods' => ['GET'],
        ],
```

the given generateUri is: string '/it}' (length=4)

It should be: string '/it' (length=3)
