### PR TITLE
use stable version 1.0.0 of nikic/fast-route, no code changes since 0.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^5.5 || ^7.0",
-        "nikic/fast-route": "^0.8.0",
+        "nikic/fast-route": "^1.0.0",
         "psr/http-message": "^1.0",
         "zendframework/zend-expressive-router": "^1.0"
     },


### PR DESCRIPTION
The package maintainer has [nothing changed since 0.8.0](https://github.com/nikic/FastRoute/releases/tag/v1.0.0).
