### PR TITLE
Remove leftover regex char classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#19](https://github.com/zendframework/zend-expressive-fastroute/pull/19) fixes
+  route generation for optional segments with regex char classes: e.g.
+  `[/{param:my-[a-z]+}]`
 
 ## 1.2.0 - 2016-06-16
 

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -172,10 +172,10 @@ REGEX;
         }
 
         // 1. remove optional segments' ending delimiters
-        //    and remove leftover regex char classes `:[` (issue #18)
+        //    and remove leftover regex char classes like `:[` and `:prefix-[` (issue #18)
         // 2. split path into an array of optional segments and remove those
         //    containing unsubstituted parameters starting from the last segment
-        $path = str_replace([']', ':['], '', $path);
+        $path = preg_replace('/\]|:.*\[/', '', $path);
         $segs = array_reverse(explode('[', $path));
         foreach ($segs as $n => $seg) {
             if (strpos($seg, '{') !== false) {

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -172,9 +172,10 @@ REGEX;
         }
 
         // 1. remove optional segments' ending delimiters
+        //    and remove leftover regex char classes `:[` (issue #18)
         // 2. split path into an array of optional segments and remove those
         //    containing unsubstituted parameters starting from the last segment
-        $path = str_replace(']', '', $path);
+        $path = str_replace([']', ':['], '', $path);
         $segs = array_reverse(explode('[', $path));
         foreach ($segs as $n => $seg) {
             if (strpos($seg, '{') !== false) {

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -225,6 +225,7 @@ class FastRouteRouterTest extends TestCase
             new Route('/index[/{page:\d+}]', 'foo', ['GET'], 'index'),
             new Route('/extra[/{page:\d+}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra'),
             new Route('/page[/{page:\d+}/{locale:[a-z]{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'limit'),
+            new Route('/api/{res:[a-z]+}[/{resId:\d+}[/{rel:[a-z]+}[/{relId:\d+}]]]', 'foo', ['GET'], 'api'),
         ];
 
         // @codingStandardsIgnoreStart
@@ -239,6 +240,10 @@ class FastRouteRouterTest extends TestCase
             'extra-42'               => [$routes, '/extra/42',                   ['extra', ['page' => 42]]],
             'extra-optional-segment' => [$routes, '/extra/42/optional-segment',  ['extra', ['page' => 42, 'extra' => 'segment']]],
             'limit'                  => [$routes, '/page/2/en/optional-segment', ['limit', ['locale' => 'en', 'page' => 2, 'extra' => 'segment']]],
+            'api-optional-regex'     => [$routes, '/api/foo',                    ['api', ['res' => 'foo']]],
+            'api-resource-id'        => [$routes, '/api/foo/1',                  ['api', ['res' => 'foo', 'resId' => 1]]],
+            'api-relation'           => [$routes, '/api/foo/1/bar',              ['api', ['res' => 'foo', 'resId' => 1, 'rel' => 'bar']]],
+            'api-relation-id'        => [$routes, '/api/foo/1/bar/2',            ['api', ['res' => 'foo', 'resId' => 1, 'rel' => 'bar', 'relId' => 2]]],
         ];
         // @codingStandardsIgnoreEnd
     }

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -226,6 +226,7 @@ class FastRouteRouterTest extends TestCase
             new Route('/extra[/{page:\d+}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra'),
             new Route('/page[/{page:\d+}/{locale:[a-z]{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'limit'),
             new Route('/api/{res:[a-z]+}[/{resId:\d+}[/{rel:[a-z]+}[/{relId:\d+}]]]', 'foo', ['GET'], 'api'),
+            new Route('/optional-regex[/{optional:prefix-[a-z]+}]', 'foo', ['GET'], 'optional-regex'),
         ];
 
         // @codingStandardsIgnoreStart
@@ -244,6 +245,7 @@ class FastRouteRouterTest extends TestCase
             'api-resource-id'        => [$routes, '/api/foo/1',                  ['api', ['res' => 'foo', 'resId' => 1]]],
             'api-relation'           => [$routes, '/api/foo/1/bar',              ['api', ['res' => 'foo', 'resId' => 1, 'rel' => 'bar']]],
             'api-relation-id'        => [$routes, '/api/foo/1/bar/2',            ['api', ['res' => 'foo', 'resId' => 1, 'rel' => 'bar', 'relId' => 2]]],
+            'optional-regex'         => [$routes, '/optional-regex',             ['optional-regex']],
         ];
         // @codingStandardsIgnoreEnd
     }


### PR DESCRIPTION
This PR fixes any leftover regex char classes `:[`.

e.g.: `'/api-test/{resource:[a-z]+}[/{resourceId:\d+}[/{relation:[a-z]+}[/{relationId:\d+}]]]'`

closes #18 
