### PR TITLE
Append extra parameters to the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#21](https://github.com/zendframework/zend-expressive-fastroute/pull/21) adds
+  support for appending extra parameters to the query when generating an URI.
 
 ### Deprecated
 

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -136,6 +136,8 @@ REGEX;
      * It does *not* use the pattern to validate that the substitution value is
      * valid beforehand, however.
      *
+     * Extra parameters are added to the query.
+     *
      * @param string $name Route name.
      * @param array $substitutions Key/value pairs to substitute into the route
      *     pattern.

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -163,12 +163,21 @@ REGEX;
             $substitutions = array_merge($options['defaults'], $substitutions);
         }
 
+        $extraParameters = [];
         foreach ($substitutions as $key => $value) {
+            $oldPath = $path;
+
             $pattern = sprintf(
                 '~%s~x',
                 sprintf(self::VARIABLE_REGEX, preg_quote($key))
             );
             $path = preg_replace($pattern, $value, $path);
+
+            // Check if the path changed
+            if ($oldPath === $path) {
+                // The path didn't change, queue parameters for the query string
+                $extraParameters[$key] = $value;
+            }
         }
 
         // 1. remove optional segments' ending delimiters
@@ -188,6 +197,11 @@ REGEX;
             }
         }
         $path = implode('', array_reverse($segs));
+
+        // Add extra parameters to the query
+        if (count($extraParameters) > 0) {
+            $path .= '?' . http_build_query($extraParameters);
+        }
 
         return $path;
     }

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -239,6 +239,11 @@ class FastRouteRouterTest extends TestCase
             'extra-42'               => [$routes, '/extra/42',                   ['extra', ['page' => 42]]],
             'extra-optional-segment' => [$routes, '/extra/42/optional-segment',  ['extra', ['page' => 42, 'extra' => 'segment']]],
             'limit'                  => [$routes, '/page/2/en/optional-segment', ['limit', ['locale' => 'en', 'page' => 2, 'extra' => 'segment']]],
+            'foo-extra-params'       => [$routes, '/foo/42?bar=baz',             ['foo', ['id' => 42, 'bar' => 'baz']]],
+            'index-extra-params'     => [$routes, '/index?bar=baz&qux=quux',     ['index', ['bar' => 'baz', 'qux' => 'quux']]],
+            'limit-extra-params'     => [$routes, '/page/2/en/optional-segment?foo=bar', ['limit', [
+                'locale' => 'en', 'page' => 2, 'extra' => 'segment', 'foo' => 'bar'
+            ]]],
         ];
         // @codingStandardsIgnoreEnd
     }


### PR DESCRIPTION
As requested in zendframework/zend-expressive#325, this PR adds support to append extra parameters to the query.

Given this route:

``` php
return [
    'routes' => [
        [
            'name'            => 'fo',
            'path'            => '/foo/{id:\d+}',
            'middleware'      => FooAction::class,
            'allowed_methods' => ['GET'],
        ],
    ],
];
```

Extra parameters are appended to the query:

```
// This in your template (twig in this example, but should work for others as well)
<a href="{{ path('foo', {'id': 1, 'bar': 'baz'}) }}">Foo</a>

// Will generate this:
<a href="/foo/1?bar=baz">Foo</a>
```

I'm not sure if this qualifies as a BC break since it changes behavior. However if the router is used correctly, there shouldn't be any extra parameters yet.

**NOTE: Real life tests in applications needed**
