### PR TITLE
Support OPTIONS and HEAD requests for any given route

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^5.6 || ^7.0",
         "nikic/fast-route": "^1.0.0",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive-router": "^1.3.1",
+        "zendframework/zend-expressive-router": "^1.3.2",
         "fig/http-message-util": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^5.6 || ^7.0",
         "nikic/fast-route": "^1.0.0",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive-router": "^1.0"
+        "zendframework/zend-expressive-router": "^1.3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7 || ^5.6",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "php": "^5.6 || ^7.0",
         "nikic/fast-route": "^1.0.0",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive-router": "^1.3.1"
+        "zendframework/zend-expressive-router": "^1.3.1",
+        "fig/http-message-util": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7 || ^5.6",

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -367,11 +367,7 @@ REGEX;
             $params = array_merge($options['defaults'], $params);
         }
 
-        return RouteResult::fromRouteMatch(
-            $route->getName(),
-            $route->getMiddleware(),
-            $params
-        );
+        return RouteResult::fromRoute($route, $params);
     }
 
     /**
@@ -406,6 +402,14 @@ REGEX;
 
         if ($methods === Route::HTTP_METHOD_ANY) {
             $methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'TRACE'];
+        }
+
+        if (in_array('HEAD', $methods, true) && $route->implicitHead()) {
+            unset($methods[array_search('HEAD', $methods)]);
+        }
+
+        if (in_array('OPTIONS', $methods, true) && $route->implicitOptions()) {
+            unset($methods[array_search('OPTIONS', $methods)]);
         }
 
         if (empty($methods)) {

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -48,9 +48,9 @@ EOT;
     ];
 
     /**
-     * HTTP methods used to introspect a resource (test for existence, options)
+     * HTTP methods implicitly supported by any route
      */
-    const HTTP_METHODS_INTROSPECT = [
+    const HTTP_METHODS_IMPLICIT = [
         RequestMethod::METHOD_HEAD,
         RequestMethod::METHOD_OPTIONS,
     ];
@@ -230,7 +230,7 @@ REGEX;
         $result     = $dispatcher->dispatch($method, $path);
 
         if ($result[0] !== Dispatcher::FOUND
-            && in_array($method, self::HTTP_METHODS_INTROSPECT, true)
+            && in_array($method, self::HTTP_METHODS_IMPLICIT, true)
         ) {
             $introspectionResult = $this->probeIntrospectionMethod($method, $path, $dispatcher);
             if ($introspectionResult) {

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -443,16 +443,6 @@ REGEX;
             $methods = self::HTTP_METHODS_STANDARD;
         }
 
-        // Remove HEAD from allowed methods if it was implicitly registered
-        if (in_array(RequestMethod::METHOD_HEAD, $methods, true) && $route->implicitHead()) {
-            unset($methods[array_search(RequestMethod::METHOD_HEAD, $methods)]);
-        }
-
-        // Remove OPTIONS from allowed methods if it was implicitly registered
-        if (in_array(RequestMethod::METHOD_OPTIONS, $methods, true) && $route->implicitOptions()) {
-            unset($methods[array_search(RequestMethod::METHOD_OPTIONS, $methods)]);
-        }
-
         if (empty($methods)) {
             $methods = self::HTTP_METHODS_EMPTY;
         }

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -156,6 +156,18 @@ class FastRouteRouterTest extends TestCase
         $this->assertEquals('/foo^GET', $result->getMatchedRouteName());
         $this->assertEquals('foo', $result->getMatchedMiddleware());
         $this->assertSame(['bar' => 'baz'], $result->getMatchedParams());
+
+        return ['route' => $route, 'result' => $result];
+    }
+
+    /**
+     * @depends testMatchingRouteShouldReturnSuccessfulRouteResult
+     */
+    public function testMatchedRouteResultContainsRoute(array $data)
+    {
+        $route = $data['route'];
+        $result = $data['result'];
+        $this->assertSame($route, $result->getMatchedRoute());
     }
 
     public function testMatchFailureDueToHttpMethodReturnsRouteResultWithAllowedMethods()


### PR DESCRIPTION
This patch accomplishes two goals:

- Updates the `FastRouteRouter` to use the new `RouteResult::fromRoute()` method when creating a successful route result. This ensures that consumers can retrieve the route that matched, along with its path, allowed methods, options, etc.
- Updates the `FastRouteRouter` to always honor `HEAD` and `OPTIONS` requests if the path matches _any_ attached route.

This latter was done to address zendframework/zend-expressive#398 for this routing implementation.

The approach taken updates the `match()` logic such that a routing failure for a `HEAD` or `OPTIONS` request will now have the router loop through all standard HTTP methods in an attempt to dispatch the path; if any match, a successful result is marshaled. This has a potential performance implication if there are many discrete routes with the same path. As such, we will need to recommend that consumers always register a path using `GET`, and, ideally, also register it with `HEAD` and `OPTIONS` (or specify no HTTP methods, which implies `GET`, `HEAD`, and `OPTIONS`). (Since `HEAD` requests will return true if the path matches against `GET`, this approach is fairly performant.)