### PR TITLE
Support zend-expressive-router 2.0.0

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,5 +1,5 @@
 /**
  * @see       https://github.com/zendframework/zend-expressive-fastroute for the canonical source repository
- * @copyright Copyright (c) %regexp:(20\d{2}-)?%%year% Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-fastroute/blob/master/LICENSE.md New BSD License
  */

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^5.6 || ^7.0",
         "nikic/fast-route": "^1.0.0",
         "psr/http-message": "^1.0",
-        "zendframework/zend-expressive-router": "^1.3.2",
+        "zendframework/zend-expressive-router": "^2.0",
         "fig/http-message-util": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "nikic/fast-route": "^1.0.0",
         "psr/http-message": "^1.0",
         "zendframework/zend-expressive-router": "^2.0",
-        "fig/http-message-util": "^1.1"
+        "fig/http-message-util": "^1.1",
+        "zendframework/zend-stdlib": "^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7 || ^5.6",

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-fastroute for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-fastroute/blob/master/LICENSE.md New BSD License
  */
 
@@ -14,6 +14,7 @@ use FastRoute\RouteCollector;
 use FastRoute\RouteParser\Std as RouteParser;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Zend\Expressive\Router\Exception;
+use Zend\Stdlib\ArrayUtils;
 
 /**
  * Router implementation bridging nikic/fast-route.
@@ -256,11 +257,14 @@ REGEX;
      * @param string $name Route name.
      * @param array $substitutions Key/value pairs to substitute into the route
      *     pattern.
+     * @param array $options Key/value option pairs to pass to the router for
+     *     purposes of generating a URI; takes precedence over options present
+     *     in route used to generate URI.
      * @return string URI path generated.
      * @throws Exception\InvalidArgumentException if the route name is not
      *     known.
      */
-    public function generateUri($name, array $substitutions = [])
+    public function generateUri($name, array $substitutions = [], array $options = [])
     {
         // Inject any pending routes
         $this->injectRoutes();
@@ -274,7 +278,7 @@ REGEX;
 
         $route   = $this->routes[$name];
         $path    = $route->getPath();
-        $options = $route->getOptions();
+        $options = ArrayUtils::merge($route->getOptions(), $options);
 
         if (! empty($options['defaults'])) {
             $substitutions = array_merge($options['defaults'], $substitutions);

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -376,6 +376,26 @@ class FastRouteRouterTest extends TestCase
         $this->assertEquals($expected, $uri);
     }
 
+    public function testOptionsPassedToGenerateUriOverrideThoseFromRoute()
+    {
+        $route  = new Route('/page[/{page:\d+}/{locale:[a-z]{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'limit');
+        $route->setOptions(['defaults' => [
+            'page'   => 1,
+            'locale' => 'en',
+            'extra'  => 'tag',
+        ]]);
+
+        $router = new FastRouteRouter();
+        $router->addRoute($route);
+
+        $uri = $router->generateUri('limit', [], ['defaults' => [
+            'page'   => 5,
+            'locale' => 'de',
+            'extra'  => 'sort',
+        ]]);
+        $this->assertEquals('/page/5/de/optional-sort', $uri);
+    }
+
     public function testReturnedRouteResultShouldContainRouteName()
     {
         $route = new Route('/foo', 'foo', ['GET'], 'foo-route');


### PR DESCRIPTION
Updates the zend-expressive-router requirement to 2.0.

Adds support for the `$options` argument to `FastRouteRouter::generateUri()`:

- Updates the code to merge the passed options with those from the
 route, with those passed taking precedence.
 - Added a test to demonstrate expected behavior.
 - Added zend-stdlib as a dependency, to ensure we have a properly
   working recursive array merge implementation.
 - Updated the `FastRoute` implementation to use `ArrayUtils::merge()` to
   merge passed options with route options.