### PR TITLE
Composer install - guide update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,11 +48,10 @@ To run tests:
 - Install dependencies via composer:
 
   ```console
-  $ curl -sS https://getcomposer.org/installer | php --
   $ composer install
   ```
 
-  If you don't have `curl` installed, you can also download `composer.phar` from https://getcomposer.org/
+  If you don't have `composer` installed, please download it from https://getcomposer.org/download/
 
 - Run the tests using the "test" command shipped in the `composer.json`:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,12 +104,12 @@ Your first step is to establish a public repository from which we can
 pull your work into the master repository. We recommend using
 [GitHub](https://github.com), as that is where the component is already hosted.
 
-1. Setup a [GitHub account](http://github.com/), if you haven't yet
-2. Fork the repository (http://github.com/zendframework/zend-expressive-fastroute)
+1. Setup a [GitHub account](https://github.com/), if you haven't yet
+2. Fork the repository (https://github.com/zendframework/zend-expressive-fastroute)
 3. Clone the canonical repository locally and enter it.
 
    ```console
-   $ git clone git://github.com:zendframework/zend-expressive-fastroute.git
+   $ git clone git://github.com/zendframework/zend-expressive-fastroute.git
    $ cd zend-expressive-fastroute
    ```
 


### PR DESCRIPTION
As noted by @schnittstabil here https://github.com/zendframework/zend-expressive-fastroute/pull/26#pullrequestreview-18530263 and https://github.com/zendframework/zend-stratigility/pull/97#commitcomment-20593201 guide was wrong.

Updated with link to getcomposer.org/download website.