### PR TITLE
Use the standard route parser from FastRoute

### DIFF
--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -287,7 +287,7 @@ EOT;
 
                 // Check substitute value with regex
                 $regex = '~^' . str_replace('/', '\/', $part[1]) . '$~';
-                if (!preg_match($regex, $substitutions[$part[0]])) {
+                if (! preg_match($regex, $substitutions[$part[0]])) {
                     throw new Exception\InvalidArgumentException(sprintf(
                         'Parameter value for [%s] did not match the regex `%s`',
                         $part[0],

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -285,8 +285,7 @@ EOT;
                 }
 
                 // Check substitute value with regex
-                $regex = '~^' . str_replace('/', '\/', $part[1]) . '$~';
-                if (! preg_match($regex, $substitutions[$part[0]])) {
+                if (! preg_match('~^' . $part[1] . '$~', $substitutions[$part[0]])) {
                     throw new Exception\InvalidArgumentException(sprintf(
                         'Parameter value for [%s] did not match the regex `%s`',
                         $part[0],

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -132,11 +132,11 @@ EOT;
      *   RouteGenerator.
      * - A callable that returns a GroupCountBased dispatcher will be created.
      *
-     * @param null|RouteCollector $router            If not provided, a default
-     *                                               implementation will be used.
-     * @param null|callable       $dispatcherFactory Callable that will return a
-     *                                               FastRoute dispatcher.
-     * @param array               $config            Array of custom configuration options.
+     * @param null|RouteCollector $router If not provided, a default
+     *     implementation will be used.
+     * @param null|callable $dispatcherFactory Callable that will return a
+     *     FastRoute dispatcher.
+     * @param array $config Array of custom configuration options.
      */
     public function __construct(
         RouteCollector $router = null,
@@ -167,11 +167,11 @@ EOT;
         }
 
         if (isset($config[self::CONFIG_CACHE_ENABLED])) {
-            $this->cacheEnabled = (bool) $config[self::CONFIG_CACHE_ENABLED];
+            $this->cacheEnabled = (bool)$config[self::CONFIG_CACHE_ENABLED];
         }
 
         if (isset($config[self::CONFIG_CACHE_FILE])) {
-            $this->cacheFile = (string) $config[self::CONFIG_CACHE_FILE];
+            $this->cacheFile = (string)$config[self::CONFIG_CACHE_FILE];
         }
 
         if ($this->cacheEnabled) {
@@ -228,19 +228,19 @@ EOT;
      * Generate a URI based on a given route.
      *
      * Replacements in FastRoute are written as `{name}` or `{name:<pattern>}`;
-     * this method uses `FastRoute\RouteParser\Std` to search for the best route match
-     * based on the available substitutions and generates a uri.
+     * this method uses `FastRoute\RouteParser\Std` to search for the best route
+     * match based on the available substitutions and generates a uri.
      *
-     * @param string $name          Route name.
-     * @param array  $substitutions Key/value pairs to substitute into the route
-     *                              pattern.
-     * @param array  $options       Key/value option pairs to pass to the router for
-     *                              purposes of generating a URI; takes precedence over
-     *                              options present in route used to generate URI.
+     * @param string $name Route name.
+     * @param array $substitutions Key/value pairs to substitute into the route
+     *     pattern.
+     * @param array $options Key/value option pairs to pass to the router for
+     *     purposes of generating a URI; takes precedence over options present
+     *     in route used to generate URI.
      *
      * @return string URI path generated.
-     * @throws Exception\InvalidArgumentException if the route name is not known or
-     *                              or a parameter value does not match its regex.
+     * @throws Exception\InvalidArgumentException if the route name is not known
+     *     or a parameter value does not match its regex.
      */
     public function generateUri($name, array $substitutions = [], array $options = [])
     {
@@ -317,8 +317,8 @@ EOT;
      * @param array $parts
      * @param array $substitutions
      *
-     * @return array with minimum required parameters if any are missing
-     *               or an empty array if none are missing
+     * @return array with minimum required parameters if any are missing or
+     *     an empty array if none are missing
      */
     private function missingParameters(array $parts, array $substitutions)
     {
@@ -363,7 +363,7 @@ EOT;
      * (which should be derived from the router's getData() method); this
      * approach is done to allow testing against the dispatcher.
      *
-     * @param  array|object $data Data from RouteCollection::getData()
+     * @param array|object $data Data from RouteCollection::getData()
      *
      * @return Dispatcher
      */
@@ -412,7 +412,7 @@ EOT;
     /**
      * Marshals a route result based on the results of matching and the current HTTP method.
      *
-     * @param array  $result
+     * @param array $result
      * @param string $method
      *
      * @return RouteResult
@@ -585,8 +585,8 @@ EOT;
      * Call this method for failed HEAD or OPTIONS requests, to see if another
      * method matches; if so, return the match.
      *
-     * @param string     $method
-     * @param string     $path
+     * @param string $method
+     * @param string $path
      * @param Dispatcher $dispatcher
      *
      * @return false|array False if no match found, array representing the match

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -310,10 +310,19 @@ EOT;
         ));
     }
 
-    private function hasRequiredParameters($parts, $substitutions)
+    /**
+     * Checks if all route parameters are available
+     *
+     * @param array $parts
+     * @param array $substitutions
+     *
+     * @return array|bool
+     */
+    private function hasRequiredParameters(array $parts, array $substitutions)
     {
         $requiredParameters = [];
 
+        // Gather required parameters
         foreach ($parts as $part) {
             if (is_string($part)) {
                 continue;
@@ -322,12 +331,16 @@ EOT;
             $requiredParameters[] = $part[0];
         }
 
+        // check if all required parameters exist
         foreach ($requiredParameters as $param) {
             if (! isset($substitutions[$param])) {
+                // Return the required parameters so they can be used in an
+                // exception if needed
                 return $requiredParameters;
             }
         }
 
+        // All required parameters are available
         return true;
     }
 

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -304,7 +304,7 @@ EOT;
 
         // No valid route was found: list minimal required parameters
         throw new Exception\InvalidArgumentException(sprintf(
-            'Route `%s` expects al least parameter values for [%s], but received [%s]',
+            'Route `%s` expects at least parameter values for [%s], but received [%s]',
             $name,
             implode(',', $missingParameters),
             implode(',', array_keys($substitutions))

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -304,7 +304,8 @@ EOT;
 
         // No valid route was found: list minimal required parameters
         throw new Exception\InvalidArgumentException(sprintf(
-            'Expected parameter values for at least [%s], but received [%s]',
+            'Route `%s` expects al least parameter values for [%s], but received [%s]',
+            $name,
             implode(',', $missingParameters),
             implode(',', array_keys($substitutions))
         ));

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -228,22 +228,19 @@ EOT;
      * Generate a URI based on a given route.
      *
      * Replacements in FastRoute are written as `{name}` or `{name:<pattern>}`;
-     * this method uses a regular expression to search for substitutions that
-     * match, and replaces them with the value provided.
-     *
-     * It does *not* use the pattern to validate that the substitution value is
-     * valid beforehand, however.
+     * this method uses `FastRoute\RouteParser\Std` to search for the best route match
+     * based on the available substitutions and generates a uri.
      *
      * @param string $name          Route name.
      * @param array  $substitutions Key/value pairs to substitute into the route
      *                              pattern.
      * @param array  $options       Key/value option pairs to pass to the router for
-     *                              purposes of generating a URI; takes precedence over options present
-     *                              in route used to generate URI.
+     *                              purposes of generating a URI; takes precedence over
+     *                              options present in route used to generate URI.
      *
      * @return string URI path generated.
-     * @throws Exception\InvalidArgumentException if the route name is not
-     *     known.
+     * @throws Exception\InvalidArgumentException if the route name is not known or
+     *                              or a parameter value does not match its regex.
      */
     public function generateUri($name, array $substitutions = [], array $options = [])
     {
@@ -278,9 +275,11 @@ EOT;
                 continue;
             }
 
+            // Generate the path
             $path = '';
             foreach ($parts as $part) {
                 if (is_string($part)) {
+                    // Append the string
                     $path .= $part;
                     continue;
                 }
@@ -295,12 +294,15 @@ EOT;
                     ));
                 }
 
+                // Append the substituted value
                 $path .= $substitutions[$part[0]];
             }
 
+            // Return generated path
             return $path;
         }
 
+        // No valid route was found; explain which minimal required parameters are needed
         throw new Exception\InvalidArgumentException(sprintf(
             'Expected parameter values for at least [%s], but received [%s]',
             implode(',', $requiredParameters),

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -630,7 +630,7 @@ class FastRouteRouterTest extends TestCase
         $router->addRoute($route);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('expects al least parameter values for');
+        $this->expectExceptionMessage('expects at least parameter values for');
 
         $router->generateUri('foo');
     }

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -630,7 +630,7 @@ class FastRouteRouterTest extends TestCase
         $router->addRoute($route);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected parameter values for at least [id], but received []');
+        $this->expectExceptionMessage('expects al least parameter values for');
 
         $router->generateUri('foo');
     }

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-fastroute for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-fastroute/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -448,18 +448,6 @@ class FastRouteRouterTest extends TestCase
         $this->assertEquals('foo-route', $result->getMatchedRouteName());
     }
 
-    public function testGenerateUriRaisesExceptionForIncompleteUriSubstitutions()
-    {
-        $router = new FastRouteRouter();
-        $route = new Route('/foo[/{param}[/optional-{extra}]]', 'foo', ['GET'], 'foo');
-        $router->addRoute($route);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('unsubstituted parameters');
-
-        $router->generateUri('foo', ['extra' => 'segment']);
-    }
-
     public function uriGeneratorDataProvider()
     {
         return [
@@ -641,8 +629,8 @@ class FastRouteRouterTest extends TestCase
         $route = new Route('/foo/{id}', 'foo', ['GET'], 'foo');
         $router->addRoute($route);
 
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Not enough parameters given');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected parameter values for at least [id], but received []');
 
         $router->generateUri('foo');
     }

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -631,4 +631,19 @@ class FastRouteRouterTest extends TestCase
 
         unlink($cache_file);
     }
+
+    /**
+     * Test for issue #30
+     */
+    public function testGenerateUriRaisesExceptionForMissingMandatoryParameters()
+    {
+        $router = new FastRouteRouter();
+        $route = new Route('/foo/{id}', 'foo', ['GET'], 'foo');
+        $router->addRoute($route);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Not enough parameters given');
+
+        $router->generateUri('foo');
+    }
 }

--- a/test/UriGeneratorTest.php
+++ b/test/UriGeneratorTest.php
@@ -72,7 +72,7 @@ class UriGeneratorTest extends TestCase
                 '/test/{param}',
                 ['id' => 'foo'],
                 InvalidArgumentException::class,
-                'expects al least parameter values for',
+                'expects at least parameter values for',
             ],
 
             ['/te{ param }st', ['param' => 'foo'], '/tefoost', null],

--- a/test/UriGeneratorTest.php
+++ b/test/UriGeneratorTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace ZendTest\Expressive\Router;
+
+use FastRoute\Dispatcher;
+use FastRoute\RouteCollector;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ProphecyInterface;
+use Zend\Expressive\Router\Exception\InvalidArgumentException;
+use Zend\Expressive\Router\FastRouteRouter;
+use Zend\Expressive\Router\Route;
+
+class UriGeneratorTest extends TestCase
+{
+    /**
+     * @var RouteCollector|ProphecyInterface
+     */
+    private $fastRouter;
+
+    /**
+     * @var Dispatcher|ProphecyInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var callable
+     */
+    private $dispatchCallback;
+
+    /**
+     * @var FastRouteRouter
+     */
+    private $router;
+
+    /**
+     * Test routes taken from https://github.com/nikic/FastRoute/blob/master/test/RouteParser/StdTest.php
+     *
+     * @return array
+     */
+    public function provideRoutes()
+    {
+        return [
+            'test_param_regex'       => '/test/{param:\d+}',
+            'test_param_regex_limit' => '/test/{ param : \d{1,9} }',
+            'test_optional'          => '/test[opt]',
+            'test_optional_param'    => '/test[/{param}]',
+            'param_and_opt'          => '/{param}[opt]',
+            'test_double_opt'        => '/test[/{param}[/{id:[0-9]+}]]',
+            'empty'                  => '',
+            'optional_text'          => '[test]',
+            'root_and_text'          => '/{foo-bar}',
+            'root_and_regex'         => '/{_foo:.*}',
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function provideRouteTests()
+    {
+        return [
+            // path // substitutions[] // expected // exception
+            ['/test', [], '/test', null],
+
+            ['/test/{param}', ['param' => 'foo'], '/test/foo', null],
+            [
+                '/test/{param}',
+                ['id' => 'foo'],
+                InvalidArgumentException::class,
+                'Expected parameter values for at least [param], but received [id]',
+            ],
+
+            ['/te{ param }st', ['param' => 'foo'], '/tefoost', null],
+
+            ['/test/{param1}/test2/{param2}', ['param1' => 'foo', 'param2' => 'bar'], '/test/foo/test2/bar', null],
+
+            ['/test/{param:\d+}', ['param' => 1], '/test/1', null],
+            //['/test/{param:\d+}', ['param' => 'foo'], 'exception', null],
+
+            ['/test/{ param : \d{1,9} }', ['param' => 1], '/test/1', null],
+            ['/test/{ param : \d{1,9} }', ['param' => 123456789], '/test/123456789', null],
+            ['/test/{ param : \d{1,9} }', ['param' => 0], '/test/0', null],
+            [
+                '/test/{ param : \d{1,9} }',
+                ['param' => 1234567890],
+                InvalidArgumentException::class,
+                'Parameter value for [param] did not match the regex `\d{1,9}`',
+            ],
+
+            ['/test[opt]', [], '/testopt', null],
+
+            ['/test[/{param}]', [], '/test', null],
+            ['/test[/{param}]', ['param' => 'foo'], '/test/foo', null],
+
+            ['/{param}[opt]', ['param' => 'foo'], '/fooopt', null],
+
+            ['/test[/{param}[/{id:[0-9]+}]]', [], '/test', null],
+            ['/test[/{param}[/{id:[0-9]+}]]', ['param' => 'foo'], '/test/foo', null],
+            ['/test[/{param}[/{id:[0-9]+}]]', ['param' => 'foo', 'id' => 1], '/test/foo/1', null],
+            ['/test[/{param}[/{id:[0-9]+}]]', ['id' => 1], '/test', null],
+            [
+                '/test[/{param}[/{id:[0-9]+}]]',
+                ['param' => 'foo', 'id' => 'foo'],
+                InvalidArgumentException::class,
+                'Parameter value for [id] did not match the regex `[0-9]+`',
+            ],
+
+            ['', [], '', null],
+
+            ['[test]', [], 'test', null],
+
+            ['/{foo-bar}', ['foo-bar' => 'bar'], '/bar', null],
+
+            ['/{_foo:.*}', ['_foo' => 'bar'], '/bar', null],
+        ];
+    }
+
+    protected function setUp()
+    {
+        $this->fastRouter       = $this->prophesize(RouteCollector::class);
+        $this->dispatcher       = $this->prophesize(Dispatcher::class);
+        $this->dispatchCallback = function () {
+            return $this->dispatcher->reveal();
+        };
+
+        $this->router = new FastRouteRouter(
+            $this->fastRouter->reveal(),
+            $this->dispatchCallback
+        );
+    }
+
+    /**
+     * @param $path
+     * @param $substitutions
+     * @param $expected
+     * @param $message
+     *
+     * @dataProvider provideRouteTests
+     */
+    public function testRoutes($path, $substitutions, $expected, $message)
+    {
+        $this->router->addRoute(new Route($path, 'foo', ['GET'], 'foo'));
+
+        if ($message !== null) {
+            // Test exceptions
+            $this->expectException($expected);
+            $this->expectExceptionMessage($message);
+
+            $this->router->generateUri('foo', $substitutions);
+
+            return;
+        }
+
+        $this->assertEquals($expected, $this->router->generateUri('foo', $substitutions));
+
+        // Test with extra parameter
+        $substitutions['extra'] = 'parameter';
+        $this->assertEquals($expected, $this->router->generateUri('foo', $substitutions));
+    }
+}

--- a/test/UriGeneratorTest.php
+++ b/test/UriGeneratorTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-fastroute for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-fastroute/blob/master/LICENSE.md New BSD License
+ */
 
 namespace ZendTest\Expressive\Router;
 

--- a/test/UriGeneratorTest.php
+++ b/test/UriGeneratorTest.php
@@ -72,7 +72,7 @@ class UriGeneratorTest extends TestCase
                 '/test/{param}',
                 ['id' => 'foo'],
                 InvalidArgumentException::class,
-                'Expected parameter values for at least [param], but received [id]',
+                'expects al least parameter values for',
             ],
 
             ['/te{ param }st', ['param' => 'foo'], '/tefoost', null],


### PR DESCRIPTION
Instead of using a custom regex, nikic suggests to use parsed results:
https://github.com/nikic/FastRoute/issues/66#issuecomment-130395124

This also throws errors for missing mandatory parameters (#30).

This is a work in progress and should be optimized and tested extensively.

- [x] Use FastRoute\RouteParser\Std for generating uri's
- [x] Remove regex related code
- [x] Add test for #30 
- [x] Throw an exception if value doesn't match the regex for a given parameter
- [x] Test in real life appplications