### PR TITLE
Allow zend-stdlib v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
         "zendframework/zend-expressive-router": "^2.0.1",
-        "zendframework/zend-stdlib": "^3.1 || ^2.7"
+        "zendframework/zend-stdlib": "^3.1 || 2.*"
     },
     "require-dev": {
         "malukenho/docheader": "^0.1.5",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
         "zendframework/zend-expressive-router": "^2.0.1",
-        "zendframework/zend-stdlib": "^3.1"
+        "zendframework/zend-stdlib": "^3.1 || ^2.7"
     },
     "require-dev": {
         "malukenho/docheader": "^0.1.5",


### PR DESCRIPTION
We would love to use zend-expressive-fastroute v2 but it requiring zend-stdlib v3 is a major barrier for us because we have mountains of code that uses zend-validator v2 which demands zend-stdlib v2.

If all zend-expressive-fastroute is using is the Zend\Stdlib\ArrayUtils:merge function, this function seems like it is the same in v2 and v3.

Please pull this so we can install zend-expressive-fastroute v2 and continue to have zend-validator v2 installed.