### PR TITLE
Allow usage with zend-expressive-router 3.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "nikic/fast-route": "^1.2",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-router": "^2.0.1",
+        "zendframework/zend-expressive-router": "^2.0.1 || ^3.0.0-dev || ^3.0.0",
         "zendframework/zend-stdlib": "^3.1 || 2.*"
     },
     "require-dev": {


### PR DESCRIPTION
API that we are consuming is not changing at this time, so this is fully backwards compatible.