### PR TITLE
Upgrade to zend-expressive-router 57ebf52

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -311,12 +311,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "6b2cfc3bc9ca787effccbabe190bc0aee0c62b68"
+                "reference": "57ebf529def0743ab9e781040e2a3c5b5aeb7533"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/6b2cfc3bc9ca787effccbabe190bc0aee0c62b68",
-                "reference": "6b2cfc3bc9ca787effccbabe190bc0aee0c62b68",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/57ebf529def0743ab9e781040e2a3c5b5aeb7533",
+                "reference": "57ebf529def0743ab9e781040e2a3c5b5aeb7533",
                 "shasum": ""
             },
             "require": {
@@ -363,7 +363,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2017-12-06T21:19:34+00:00"
+            "time": "2017-12-07T17:39:11+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -392,7 +392,7 @@ EOT;
             return RouteResult::fromRouteFailure($result[1]);
         }
 
-        return RouteResult::fromRouteFailure();
+        return RouteResult::fromRouteFailure(Route::HTTP_METHOD_ANY);
     }
 
     /**
@@ -419,7 +419,7 @@ EOT;
 
         if (false === $route) {
             // This likely should never occur, but is present for completeness.
-            return RouteResult::fromRouteFailure();
+            return RouteResult::fromRouteFailure(Route::HTTP_METHOD_ANY);
         }
 
         $params = $result[2];

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -349,7 +349,7 @@ class FastRouteRouterTest extends TestCase
         $this->assertInstanceOf(RouteResult::class, $result);
         $this->assertTrue($result->isFailure());
         $this->assertFalse($result->isMethodFailure());
-        $this->assertSame([], $result->getAllowedMethods());
+        $this->assertSame(['*'], $result->getAllowedMethods());
     }
 
     public function generatedUriProvider()


### PR DESCRIPTION
Picks up a change in the `RouteResult::fromRouteFailure()` signature, as well as in what `RouteResult::getAllowedMethods()` returns when any method is allowed.

Updates the `FastRouteRouter` class to always pass an argument to `RouteResult::fromRouteFailure()`, passing `Route::HTTP_METHOD_ANY` where it previously passed no argument, as these cases were cases where the failure was not due to the HTTP method.