### PR TITLE
Simplify condition and used proper constant name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "nikic/fast-route": "^1.2",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-router": "^3.0.0rc2",
+        "zendframework/zend-expressive-router": "^3.0.0rc3",
         "zendframework/zend-stdlib": "^2.0 || ^3.1"
     },
     "require-dev": {
@@ -34,7 +34,7 @@
         "phpunit/phpunit": "^7.0.2",
         "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-diactoros": "^1.7",
-        "zendframework/zend-stratigility": "^3.0.0-rc1"
+        "zendframework/zend-stratigility": "^3.0.0rc1"
     },
     "conflict": {
         "container-interop/container-interop": "<1.2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a6e41a713c2593051558358071c1f1f8",
+    "content-hash": "f86e962b5cb3402be3bdf6a37feb21e0",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -309,16 +309,16 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "3.0.0rc2",
+            "version": "3.0.0rc3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "97ea9940c72222586e832913529b097ddcc0b2e4"
+                "reference": "c4380e07a96fede84e8eabbe2698120fa3df7332"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/97ea9940c72222586e832913529b097ddcc0b2e4",
-                "reference": "97ea9940c72222586e832913529b097ddcc0b2e4",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/c4380e07a96fede84e8eabbe2698120fa3df7332",
+                "reference": "c4380e07a96fede84e8eabbe2698120fa3df7332",
                 "shasum": ""
             },
             "require": {
@@ -371,7 +371,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2018-03-06T22:42:26+00:00"
+            "time": "2018-03-07T15:38:28+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -547,8 +547,6 @@ EOT;
 
         $allowedMethods = array_unique($allowedMethods);
 
-        return empty($allowedMethods)
-            ? RouteResult::fromRouteFailure(Route::METHOD_ANY)
-            : RouteResult::fromRouteFailure($allowedMethods);
+        return RouteResult::fromRouteFailure($allowedMethods ?: Route::HTTP_METHOD_ANY);
     }
 }

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -536,7 +536,7 @@ EOT;
 
     private function marshalMethodNotAllowedResult(array $result) : RouteResult
     {
-        $path  = $result[1];
+        $path = $result[1];
         $allowedMethods = array_reduce($this->routes, function ($allowedMethods, $route) use ($path) {
             if ($path !== $route->getPath()) {
                 return $allowedMethods;
@@ -547,6 +547,6 @@ EOT;
 
         $allowedMethods = array_unique($allowedMethods);
 
-        return RouteResult::fromRouteFailure($allowedMethods ?: Route::HTTP_METHOD_ANY);
+        return RouteResult::fromRouteFailure($allowedMethods ?: []);
     }
 }

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -366,7 +366,7 @@ EOT;
             return RouteResult::fromRouteFailure($result[1]);
         }
 
-        return RouteResult::fromRouteFailure([]);
+        return RouteResult::fromRouteFailure(Route::HTTP_METHOD_ANY);
     }
 
     /**
@@ -534,6 +534,6 @@ EOT;
 
         $allowedMethods = array_unique($allowedMethods);
 
-        return RouteResult::fromRouteFailure($allowedMethods ?: []);
+        return RouteResult::fromRouteFailure($allowedMethods ?: Route::HTTP_METHOD_ANY);
     }
 }

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -42,15 +42,6 @@ EOT;
     public const CONFIG_CACHE_FILE = 'cache_file';
 
     /**
-     * HTTP methods that always match when no methods provided.
-     */
-    public const HTTP_METHODS_EMPTY = [
-        RequestMethod::METHOD_GET,
-        RequestMethod::METHOD_HEAD,
-        RequestMethod::METHOD_OPTIONS,
-    ];
-
-    /**
      * Standard HTTP methods against which to test HEAD/OPTIONS requests.
      */
     public const HTTP_METHODS_STANDARD = [
@@ -375,7 +366,7 @@ EOT;
             return RouteResult::fromRouteFailure($result[1]);
         }
 
-        return RouteResult::fromRouteFailure(Route::HTTP_METHOD_ANY);
+        return RouteResult::fromRouteFailure([]);
     }
 
     /**
@@ -442,10 +433,6 @@ EOT;
 
         if ($methods === Route::HTTP_METHOD_ANY) {
             $methods = self::HTTP_METHODS_STANDARD;
-        }
-
-        if (empty($methods)) {
-            $methods = self::HTTP_METHODS_EMPTY;
         }
 
         $this->router->addRoute($methods, $route->getPath(), $route->getPath());

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -534,6 +534,6 @@ EOT;
 
         $allowedMethods = array_unique($allowedMethods);
 
-        return RouteResult::fromRouteFailure($allowedMethods ?: Route::HTTP_METHOD_ANY);
+        return RouteResult::fromRouteFailure($allowedMethods);
     }
 }

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -12,13 +12,11 @@ namespace ZendTest\Expressive\Router;
 use FastRoute\Dispatcher\GroupCountBased as Dispatcher;
 use FastRoute\RouteCollector;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
-use Generator;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ProphecyInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\MiddlewareInterface;
-use Zend\Diactoros\ServerRequest;
 use Zend\Expressive\Router\Exception\InvalidArgumentException;
 use Zend\Expressive\Router\FastRouteRouter;
 use Zend\Expressive\Router\Route;
@@ -633,12 +631,5 @@ class FastRouteRouterTest extends TestCase
         $this->expectExceptionMessage('expects at least parameter values for');
 
         $router->generateUri('foo');
-    }
-
-    public function method() : Generator
-    {
-        foreach (FastRouteRouter::HTTP_METHODS_STANDARD as $method) {
-            yield $method => [$method];
-        }
     }
 }

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -330,7 +330,7 @@ class FastRouteRouterTest extends TestCase
     {
         $route = new Route('/foo', $this->getMiddleware(), [RequestMethod::METHOD_GET]);
 
-        $uri     = $this->prophesize(UriInterface::class);
+        $uri = $this->prophesize(UriInterface::class);
         $uri->getPath()->willReturn('/bar');
 
         $request = $this->prophesize(ServerRequestInterface::class);

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -136,20 +136,6 @@ class FastRouteRouterTest extends TestCase
         $router->generateUri($route->getName());
     }
 
-    public function testIfRouteSpecifiesNoHttpMethodsFastRouteIsPassedHardCodedListOfMethods()
-    {
-        $route = new Route('/foo', $this->getMiddleware(), []);
-        $this->fastRouter
-            ->addRoute([], '/foo', '/foo')
-            ->shouldBeCalled();
-
-        $router = $this->getRouter();
-        $router->addRoute($route);
-
-        // routes are not injected until match or generateUri
-        $router->generateUri($route->getName());
-    }
-
     public function testMatchingRouteShouldReturnSuccessfulRouteResult()
     {
         $middleware = $this->getMiddleware();
@@ -654,24 +640,5 @@ class FastRouteRouterTest extends TestCase
         foreach (FastRouteRouter::HTTP_METHODS_STANDARD as $method) {
             yield $method => [$method];
         }
-    }
-
-    /**
-     * @dataProvider method
-     */
-    public function testNoMethodsAllowedForRoute(string $method)
-    {
-        $router = new FastRouteRouter();
-        $route = new Route('/foo', $this->getMiddleware(), []);
-        $router->addRoute($route);
-
-        $request = new ServerRequest(['REQUEST_METHOD' => $method], [], '/foo', $method);
-
-        $result = $router->match($request);
-
-        $this->assertFalse($result->getMatchedRoute());
-        $this->assertSame([], $result->getAllowedMethods(), $method);
-        $this->assertTrue($result->isFailure());
-        $this->assertTrue($result->isMethodFailure());
     }
 }

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -140,11 +140,7 @@ class FastRouteRouterTest extends TestCase
     {
         $route = new Route('/foo', $this->getMiddleware(), []);
         $this->fastRouter
-            ->addRoute(
-                FastRouteRouter::HTTP_METHODS_EMPTY,
-                '/foo',
-                '/foo'
-            )
+            ->addRoute([], '/foo', '/foo')
             ->shouldBeCalled();
 
         $router = $this->getRouter();


### PR DESCRIPTION
The wrong constant name was used: `Route::METHOD_ANY ` instead of `Route::HTTP_METHOD_ANY`.

Also simplify condition as in both case we call `RouteResult::fromRouteFailure`.