### PR TITLE
Backport fixes from release-3.0.0 using zend-expressive-router 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "nikic/fast-route": "^1.2",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "zendframework/zend-expressive-router": "^2.0.1",
+        "zendframework/zend-expressive-router": "^2.4",
         "zendframework/zend-stdlib": "^3.1 || 2.*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d1639849675bb27034d18a929ab5858",
+    "content-hash": "c57b5d11b94c603018fd0ed32c87b7ad",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -58,16 +58,16 @@
         },
         {
             "name": "http-interop/http-middleware",
-            "version": "0.4.1",
+            "version": "0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9"
+                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/9a801fe60e70d5d608b61d56b2dcde29516c81b9",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9",
+                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/b49e1f9f6c584e704317b563302e566b8ce11858",
+                "reference": "b49e1f9f6c584e704317b563302e566b8ce11858",
                 "shasum": ""
             },
             "require": {
@@ -82,7 +82,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Interop\\Http\\ServerMiddleware\\": "src/"
+                    "Interop\\Http\\Server\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -97,17 +97,16 @@
             ],
             "description": "Common interface for HTTP server-side middleware",
             "keywords": [
-                "factory",
                 "http",
                 "middleware",
                 "psr",
-                "psr-17",
+                "psr-15",
                 "psr-7",
                 "request",
                 "response"
             ],
             "abandoned": "http-interop/http-server-middleware",
-            "time": "2017-01-14T15:23:42+00:00"
+            "time": "2017-09-18T15:27:03+00:00"
         },
         {
             "name": "nikic/fast-route",
@@ -341,31 +340,33 @@
                 "psr-15",
                 "webimpress"
             ],
+            "abandoned": "psr/http-server-middleware",
             "time": "2017-10-17T17:31:10+00:00"
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "2.2.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4"
+                "reference": "39933d4f02477ff7481a89dcc17db654a2ec54e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
-                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/39933d4f02477ff7481a89dcc17db654a2ec54e1",
+                "reference": "39933d4f02477ff7481a89dcc17db654a2ec54e1",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
                 "php": "^5.6 || ^7.0",
+                "psr/container": "^1.0",
                 "psr/http-message": "^1.0.1",
                 "webimpress/http-middleware-compatibility": "^0.1.1"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
@@ -376,8 +377,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev",
-                    "dev-develop": "2.3-dev"
+                    "dev-master": "2.4.x-dev",
+                    "dev-develop": "3.0.x-dev"
+                },
+                "zf": {
+                    "config-provider": "Zend\\Expressive\\Router\\ConfigProvider"
                 }
             },
             "autoload": {
@@ -391,13 +395,16 @@
             ],
             "description": "Router subcomponent for Expressive",
             "keywords": [
+                "ZendFramework",
                 "expressive",
                 "http",
                 "middleware",
                 "psr",
-                "psr-7"
+                "psr-7",
+                "zend-expressive",
+                "zf"
             ],
-            "time": "2017-10-09T18:44:11+00:00"
+            "time": "2018-03-08T15:03:15+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -28,14 +28,18 @@ class FastRouteRouter implements RouterInterface
 <?php
 return %s;
 EOT;
+
     /**
      * @const string Configuration key used to enable/disable fastroute caching
      */
+
     const CONFIG_CACHE_ENABLED = 'cache_enabled';
     /**
      * @const string Configuration key used to set the cache file path
      */
+
     const CONFIG_CACHE_FILE = 'cache_file';
+
     /**
      * HTTP methods that always match when no methods provided.
      */
@@ -44,6 +48,7 @@ EOT;
         RequestMethod::METHOD_HEAD,
         RequestMethod::METHOD_OPTIONS,
     ];
+
     /**
      * HTTP methods implicitly supported by any route
      */
@@ -51,6 +56,7 @@ EOT;
         RequestMethod::METHOD_HEAD,
         RequestMethod::METHOD_OPTIONS,
     ];
+
     /**
      * Standard HTTP methods against which to test HEAD/OPTIONS requests.
      */
@@ -210,16 +216,16 @@ EOT;
         $dispatcher = $this->getDispatcher($dispatchData);
         $result     = $dispatcher->dispatch($method, $path);
 
-        if ($result[0] !== Dispatcher::FOUND
+        if ($result[0] === Dispatcher::METHOD_NOT_ALLOWED
             && in_array($method, self::HTTP_METHODS_IMPLICIT, true)
         ) {
-            $introspectionResult = $this->probeIntrospectionMethod($method, $path, $dispatcher);
-            if ($introspectionResult) {
-                return $this->marshalMatchedRoute($introspectionResult, $method);
+            if (false !== ($result = $this->probeIntrospectionMethod($method, $path, $dispatcher))) {
+                return $this->marshalImplicitMethodResult($method, $result);
             }
+            return $this->marshalFailedRoute($result);
         }
 
-        return ($result[0] !== Dispatcher::FOUND)
+        return $result[0] !== Dispatcher::FOUND
             ? $this->marshalFailedRoute($result)
             : $this->marshalMatchedRoute($result, $method);
     }
@@ -440,14 +446,7 @@ EOT;
             return RouteResult::fromRouteFailure();
         }
 
-        $params = $result[2];
-
-        $options = $route->getOptions();
-        if (! empty($options['defaults'])) {
-            $params = array_merge($options['defaults'], $params);
-        }
-
-        return RouteResult::fromRoute($route, $params);
+        return RouteResult::fromRoute($route, $this->marshalMatchedParams($route, $result));
     }
 
     /**
@@ -604,5 +603,65 @@ EOT;
         }
 
         return false;
+    }
+
+    /**
+     * @param string $method
+     * @return RouteResult
+     */
+    private function marshalIMplicitMethodResult($method, array $result)
+    {
+        $path = $result[1];
+        $route = array_reduce($this->routes, function ($matched, $route) use ($method, $path) {
+            if ($matched) {
+                return $matched;
+            }
+
+            if ($path !== $route->getPath()) {
+                return $matched;
+            }
+
+            return $route;
+        }, false);
+
+        $implicitRoute = new Route(
+            $path,
+            $route->getMiddleware(),
+            $this->marshalAllowedMethodsForPath($path),
+            $route->getName()
+        );
+        $implicitRoute->setOptions($route->getOptions());
+
+        return RouteResult::fromRoute(
+            $implicitRoute,
+            $this->marshalMatchedParams($implicitRoute, $result)
+        );
+    }
+
+    /**
+     * @param string $path
+     * @return array
+     */
+    private function marshalAllowedMethodsForPath($path)
+    {
+        $allowedMethods = array_reduce($this->routes, function ($allowedMethods, $route) use ($path) {
+            if ($path !== $route->getPath()) {
+                return $allowedMethods;
+            }
+
+            return array_merge($allowedMethods, $route->getAllowedMethods());
+        }, []);
+
+        return array_unique($allowedMethods);
+    }
+
+    private function marshalMatchedParams(Route $route, array $result)
+    {
+        $params = $result[2];
+        $options = $route->getOptions();
+        if (! empty($options['defaults'])) {
+            $params = array_merge($options['defaults'], $params);
+        }
+        return $params;
     }
 }

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -32,12 +32,11 @@ EOT;
     /**
      * @const string Configuration key used to enable/disable fastroute caching
      */
-
     const CONFIG_CACHE_ENABLED = 'cache_enabled';
+
     /**
      * @const string Configuration key used to set the cache file path
      */
-
     const CONFIG_CACHE_FILE = 'cache_file';
 
     /**

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -427,7 +427,12 @@ class FastRouteRouterTest extends TestCase
 
     public function testOptionsPassedToGenerateUriOverrideThoseFromRoute()
     {
-        $route  = new Route('/page[/{page:\d+}/{locale:[a-z]{2}}[/optional-{extra:\w+}]]', $this->middleware, ['GET'], 'limit');
+        $route = new Route(
+            '/page[/{page:\d+}/{locale:[a-z]{2}}[/optional-{extra:\w+}]]',
+            $this->middleware,
+            ['GET'],
+            'limit'
+        );
         $route->setOptions(['defaults' => [
             'page'   => 1,
             'locale' => 'en',

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ProphecyInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Zend\Expressive\Router\Exception\InvalidArgumentException;
 use Zend\Expressive\Router\FastRouteRouter;
 use Zend\Expressive\Router\Route;
@@ -35,6 +36,11 @@ class FastRouteRouterTest extends TestCase
      */
     private $dispatchCallback;
 
+    /**
+     * @var MiddlewareInterface|ProphecyInterface
+     */
+    private $middleware;
+
     public function setUp()
     {
         $this->fastRouter = $this->prophesize(RouteCollector::class);
@@ -42,6 +48,7 @@ class FastRouteRouterTest extends TestCase
         $this->dispatchCallback = function () {
             return $this->dispatcher->reveal();
         };
+        $this->middleware = $this->prophesize(MiddlewareInterface::class)->reveal();
     }
 
     public function getRouter()
@@ -60,7 +67,7 @@ class FastRouteRouterTest extends TestCase
 
     public function testAddingRouteAggregatesRoute()
     {
-        $route = new Route('/foo', 'foo', ['GET']);
+        $route = new Route('/foo', $this->middleware, ['GET']);
         $router = $this->getRouter();
         $router->addRoute($route);
         $this->assertAttributeContains($route, 'routesToInject', $router);
@@ -71,7 +78,7 @@ class FastRouteRouterTest extends TestCase
      */
     public function testMatchingInjectsRouteIntoFastRoute()
     {
-        $route = new Route('/foo', 'foo', ['GET']);
+        $route = new Route('/foo', $this->middleware, ['GET']);
         $this->fastRouter->addRoute(['GET'], '/foo', '/foo')->shouldBeCalled();
         $this->fastRouter->getData()->shouldBeCalled();
         $this->dispatcher->dispatch('GET', '/foo')->willReturn([
@@ -98,7 +105,7 @@ class FastRouteRouterTest extends TestCase
      */
     public function testGeneratingUriInjectsRouteIntoFastRoute()
     {
-        $route = new Route('/foo', 'foo', ['GET'], 'foo');
+        $route = new Route('/foo', $this->middleware, ['GET'], 'foo');
         $this->fastRouter->addRoute(['GET'], '/foo', '/foo')->shouldBeCalled();
 
         $router = $this->getRouter();
@@ -109,7 +116,7 @@ class FastRouteRouterTest extends TestCase
 
     public function testIfRouteSpecifiesAnyHttpMethodFastRouteIsPassedHardCodedListOfMethods()
     {
-        $route = new Route('/foo', 'foo');
+        $route = new Route('/foo', $this->middleware);
         $this->fastRouter
             ->addRoute(
                 FastRouteRouter::HTTP_METHODS_STANDARD,
@@ -127,7 +134,7 @@ class FastRouteRouterTest extends TestCase
 
     public function testIfRouteSpecifiesNoHttpMethodsFastRouteIsPassedHardCodedListOfMethods()
     {
-        $route = new Route('/foo', 'foo', []);
+        $route = new Route('/foo', $this->middleware, []);
         $this->fastRouter
             ->addRoute(
                 FastRouteRouter::HTTP_METHODS_EMPTY,
@@ -145,7 +152,7 @@ class FastRouteRouterTest extends TestCase
 
     public function testMatchingRouteShouldReturnSuccessfulRouteResult()
     {
-        $route = new Route('/foo', 'foo', ['GET']);
+        $route = new Route('/foo', $this->middleware, ['GET']);
 
         $uri     = $this->prophesize(UriInterface::class);
         $uri->getPath()->willReturn('/foo');
@@ -169,7 +176,7 @@ class FastRouteRouterTest extends TestCase
         $this->assertInstanceOf(RouteResult::class, $result);
         $this->assertTrue($result->isSuccess());
         $this->assertEquals('/foo^GET', $result->getMatchedRouteName());
-        $this->assertEquals('foo', $result->getMatchedMiddleware());
+        $this->assertEquals($this->middleware, $result->getMatchedMiddleware());
         $this->assertSame(['bar' => 'baz'], $result->getMatchedParams());
 
         return ['route' => $route, 'result' => $result];
@@ -203,7 +210,7 @@ class FastRouteRouterTest extends TestCase
     public function testRouteNotSpecifyingOptionsImpliesOptionsIsSupportedAndMatchesWhenGetOrHeadIsAllowed(
         $method
     ) {
-        $route = new Route('/foo', 'foo', ['POST', $method]);
+        $route = new Route('/foo', $this->middleware, ['POST', $method]);
 
         $uri = $this->prophesize(UriInterface::class);
         $uri->getPath()->willReturn('/foo');
@@ -226,7 +233,9 @@ class FastRouteRouterTest extends TestCase
 
     public function testRouteNotSpecifyingOptionsGetOrHeadMatchesOptions()
     {
-        $route = new Route('/foo', 'foo', ['POST']);
+        $route = new Route('/foo', $this->middleware, ['POST']);
+        $route2 = new Route('/foo', $this->middleware, ['PATCH']);
+        $route3 = new Route('/foo', $this->middleware, ['PUT']);
 
         $uri = $this->prophesize(UriInterface::class);
         $uri->getPath()->willReturn('/foo');
@@ -239,15 +248,24 @@ class FastRouteRouterTest extends TestCase
         // OPTIONS requests when the route does not support them. As a result,
         // it does not mock the router or dispatcher.
         $router = new FastRouteRouter();
-        $router->addRoute($route); // Must add, so we can determine middleware later
+
+        // Must add routes, so we can determine allowed methods later
+        $router->addRoute($route);
+        $router->addRoute($route2);
+        $router->addRoute($route3);
+
         $result = $router->match($request->reveal());
+
         $this->assertInstanceOf(RouteResult::class, $result);
         $this->assertTrue($result->isSuccess());
+        $this->assertEquals(['POST', 'PATCH', 'PUT'], $result->getAllowedMethods());
     }
 
     public function testRouteNotSpecifyingGetOrHeadDoesMatcheshHead()
     {
-        $route = new Route('/foo', 'foo', ['POST']);
+        $route = new Route('/foo', $this->middleware, ['POST']);
+        $route2 = new Route('/foo', $this->middleware, ['PATCH']);
+        $route3 = new Route('/foo', $this->middleware, ['PUT']);
 
         $uri = $this->prophesize(UriInterface::class);
         $uri->getPath()->willReturn('/foo');
@@ -260,10 +278,16 @@ class FastRouteRouterTest extends TestCase
         // HEAD requests when the route does not support them. As a result,
         // it does not mock the router or dispatcher.
         $router = new FastRouteRouter();
-        $router->addRoute($route); // Must add, so we can determine middleware later
+
+        // Must add routes, so we can determine allowed methods later
+        $router->addRoute($route);
+        $router->addRoute($route2);
+        $router->addRoute($route3);
+
         $result = $router->match($request->reveal());
         $this->assertInstanceOf(RouteResult::class, $result);
         $this->assertTrue($result->isSuccess());
+        $this->assertEquals(['POST', 'PATCH', 'PUT'], $result->getAllowedMethods());
     }
 
     /**
@@ -271,7 +295,7 @@ class FastRouteRouterTest extends TestCase
      */
     public function testRouteSpecifyingGetMatchesHead()
     {
-        $route = new Route('/foo', 'foo', ['GET']);
+        $route = new Route('/foo', $this->middleware, ['GET']);
 
         $uri = $this->prophesize(UriInterface::class);
         $uri->getPath()->willReturn('/foo');
@@ -292,7 +316,7 @@ class FastRouteRouterTest extends TestCase
 
     public function testMatchFailureDueToHttpMethodReturnsRouteResultWithAllowedMethods()
     {
-        $route = new Route('/foo', 'foo', ['POST']);
+        $route = new Route('/foo', $this->middleware, ['POST']);
 
         $uri     = $this->prophesize(UriInterface::class);
         $uri->getPath()->willReturn('/foo');
@@ -320,7 +344,7 @@ class FastRouteRouterTest extends TestCase
 
     public function testMatchFailureNotDueToHttpMethodReturnsGenericRouteFailureResult()
     {
-        $route = new Route('/foo', 'foo', ['GET']);
+        $route = new Route('/foo', $this->middleware, ['GET']);
 
         $uri     = $this->prophesize(UriInterface::class);
         $uri->getPath()->willReturn('/bar');
@@ -347,16 +371,17 @@ class FastRouteRouterTest extends TestCase
 
     public function generatedUriProvider()
     {
+        $middleware = $this->prophesize(MiddlewareInterface::class)->reveal();
         $routes = [
-            new Route('/foo', 'foo', ['POST'], 'foo-create'),
-            new Route('/foo', 'foo', ['GET'], 'foo-list'),
-            new Route('/foo/{id:\d+}', 'foo', ['GET'], 'foo'),
-            new Route('/bar/{baz}', 'bar', Route::HTTP_METHOD_ANY, 'bar'),
-            new Route('/index[/{page:\d+}]', 'foo', ['GET'], 'index'),
-            new Route('/extra[/{page:\d+}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'extra'),
-            new Route('/page[/{page:\d+}/{locale:[a-z]{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'limit'),
-            new Route('/api/{res:[a-z]+}[/{resId:\d+}[/{rel:[a-z]+}[/{relId:\d+}]]]', 'foo', ['GET'], 'api'),
-            new Route('/optional-regex[/{optional:prefix-[a-z]+}]', 'foo', ['GET'], 'optional-regex'),
+            new Route('/foo', $middleware, ['POST'], 'foo-create'),
+            new Route('/foo', $middleware, ['GET'], 'foo-list'),
+            new Route('/foo/{id:\d+}', $middleware, ['GET'], 'foo'),
+            new Route('/bar/{baz}', $middleware, Route::HTTP_METHOD_ANY, 'bar'),
+            new Route('/index[/{page:\d+}]', $middleware, ['GET'], 'index'),
+            new Route('/extra[/{page:\d+}[/optional-{extra:\w+}]]', $middleware, ['GET'], 'extra'),
+            new Route('/page[/{page:\d+}/{locale:[a-z]{2}}[/optional-{extra:\w+}]]', $middleware, ['GET'], 'limit'),
+            new Route('/api/{res:[a-z]+}[/{resId:\d+}[/{rel:[a-z]+}[/{relId:\d+}]]]', $middleware, ['GET'], 'api'),
+            new Route('/optional-regex[/{optional:prefix-[a-z]+}]', $middleware, ['GET'], 'optional-regex'),
         ];
 
         // @codingStandardsIgnoreStart
@@ -402,7 +427,7 @@ class FastRouteRouterTest extends TestCase
 
     public function testOptionsPassedToGenerateUriOverrideThoseFromRoute()
     {
-        $route  = new Route('/page[/{page:\d+}/{locale:[a-z]{2}}[/optional-{extra:\w+}]]', 'foo', ['GET'], 'limit');
+        $route  = new Route('/page[/{page:\d+}/{locale:[a-z]{2}}[/optional-{extra:\w+}]]', $this->middleware, ['GET'], 'limit');
         $route->setOptions(['defaults' => [
             'page'   => 1,
             'locale' => 'en',
@@ -422,7 +447,7 @@ class FastRouteRouterTest extends TestCase
 
     public function testReturnedRouteResultShouldContainRouteName()
     {
-        $route = new Route('/foo', 'foo', ['GET'], 'foo-route');
+        $route = new Route('/foo', $this->middleware, ['GET'], 'foo-route');
 
         $uri     = $this->prophesize(UriInterface::class);
         $uri->getPath()->willReturn('/foo');
@@ -477,7 +502,7 @@ class FastRouteRouterTest extends TestCase
     {
         $router = new FastRouteRouter();
 
-        $route = new Route('/foo/{param1}/{param2}', 'foo', ['GET'], 'foo');
+        $route = new Route('/foo/{param1}/{param2}', $this->middleware, ['GET'], 'foo');
         $route->setOptions([
             'defaults' => [
                 'param1' => 'abc',
@@ -500,7 +525,7 @@ class FastRouteRouterTest extends TestCase
     {
         $router = new FastRouteRouter();
 
-        $route = new Route('/foo/{param1}/{param2}', 'foo', ['GET'], 'foo');
+        $route = new Route('/foo/{param1}/{param2}', $this->middleware, ['GET'], 'foo');
         $route->setOptions([
             'defaults' => [
                 'param1' => 'abc',
@@ -543,7 +568,7 @@ class FastRouteRouterTest extends TestCase
     {
         $router = new FastRouteRouter();
 
-        $route = new Route('/foo/{param1}[/{param2}]', 'foo', ['GET'], 'foo');
+        $route = new Route('/foo/{param1}[/{param2}]', $this->middleware, ['GET'], 'foo');
         $route->setOptions([
             'defaults' => [
                 'param1' => 'abc',
@@ -589,7 +614,7 @@ class FastRouteRouterTest extends TestCase
 
         $request = $this->createServerRequestProphecy('/foo', 'GET');
 
-        $route = new Route('/foo', 'fooHandler', ['GET'], 'foo');
+        $route = new Route('/foo', $this->middleware, ['GET'], 'foo');
 
         $router1 = $this->createCachingRouter($config, $route);
         $router1->match($request->reveal());
@@ -615,7 +640,7 @@ class FastRouteRouterTest extends TestCase
         $this->assertInstanceOf(RouteResult::class, $result);
         $this->assertTrue($result->isSuccess());
         $this->assertEquals('foo', $result->getMatchedRouteName());
-        $this->assertEquals('fooHandler', $result->getMatchedMiddleware());
+        $this->assertEquals($this->middleware, $result->getMatchedMiddleware());
 
         unlink($cache_file);
     }
@@ -626,7 +651,7 @@ class FastRouteRouterTest extends TestCase
     public function testGenerateUriRaisesExceptionForMissingMandatoryParameters()
     {
         $router = new FastRouteRouter();
-        $route = new Route('/foo/{id}', 'foo', ['GET'], 'foo');
+        $route = new Route('/foo/{id}', $this->middleware, ['GET'], 'foo');
         $router->addRoute($route);
 
         $this->expectException(InvalidArgumentException::class);

--- a/test/UriGeneratorTest.php
+++ b/test/UriGeneratorTest.php
@@ -11,6 +11,7 @@ use FastRoute\Dispatcher;
 use FastRoute\RouteCollector;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ProphecyInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Zend\Expressive\Router\Exception\InvalidArgumentException;
 use Zend\Expressive\Router\FastRouteRouter;
 use Zend\Expressive\Router\Route;
@@ -31,6 +32,11 @@ class UriGeneratorTest extends TestCase
      * @var callable
      */
     private $dispatchCallback;
+
+    /**
+     * @var MiddlewareInterface|ProphecyInterface
+     */
+    private $middleware;
 
     /**
      * @var FastRouteRouter
@@ -132,6 +138,8 @@ class UriGeneratorTest extends TestCase
             $this->fastRouter->reveal(),
             $this->dispatchCallback
         );
+
+        $this->middleware = $this->prophesize(MiddlewareInterface::class)->reveal();
     }
 
     /**
@@ -144,7 +152,7 @@ class UriGeneratorTest extends TestCase
      */
     public function testRoutes($path, $substitutions, $expected, $message)
     {
-        $this->router->addRoute(new Route($path, 'foo', ['GET'], 'foo'));
+        $this->router->addRoute(new Route($path, $this->middleware, ['GET'], 'foo'));
 
         if ($message !== null) {
             // Test exceptions


### PR DESCRIPTION
This patch updates the component to the zend-expressive-router 2.4 series, and backports some of the fixes/changes from the release-3.0.0 series. In particular, it ensures that implicit HEAD and OPTIONS requests return the _full_ list of available HTTP methods for a matched route; previously, they would only return the methods associated with the first route that matched.