### PR TITLE
Added default value for private property (empty array)

### DIFF
--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -116,7 +116,7 @@ EOT;
      *
      * @var Route[]
      */
-    private $routes;
+    private $routes = [];
 
     /**
      * Routes to inject into the underlying RouteCollector.

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -664,4 +664,13 @@ class FastRouteRouterTest extends TestCase
 
         $router->generateUri('foo');
     }
+
+    public function testGenerateUriRaisesExceptionForNotFoundRoute()
+    {
+        $router = new FastRouteRouter();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('route not found');
+        $router->generateUri('foo');
+    }
 }


### PR DESCRIPTION
In case we don't have any routes and we try to `generateUri` we are getting error:
```
array_key_exists() expects parameter 2 to be array, null given
/src/FastRouteRouter.php:255
```
