### PR TITLE
Fix exception type thrown by router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#56](https://github.com/zendframework/zend-expressive-fastroute/pull/56)
+  makes the router use the exception documented in `RouterInterface`.
 
 ## 3.0.0rc4 - 2018-03-07
 

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -211,7 +211,7 @@ EOT;
      *     in route used to generate URI.
      *
      * @return string URI path generated.
-     * @throws Exception\InvalidArgumentException if the route name is not known
+     * @throws Exception\RuntimeException if the route name is not known
      *     or a parameter value does not match its regex.
      */
     public function generateUri(string $name, array $substitutions = [], array $options = []) : string
@@ -220,7 +220,7 @@ EOT;
         $this->injectRoutes();
 
         if (! array_key_exists($name, $this->routes)) {
-            throw new Exception\InvalidArgumentException(sprintf(
+            throw new Exception\RuntimeException(sprintf(
                 'Cannot generate URI for route "%s"; route not found',
                 $name
             ));
@@ -258,7 +258,7 @@ EOT;
 
                 // Check substitute value with regex
                 if (! preg_match('~^' . $part[1] . '$~', (string) $substitutions[$part[0]])) {
-                    throw new Exception\InvalidArgumentException(sprintf(
+                    throw new Exception\RuntimeException(sprintf(
                         'Parameter value for [%s] did not match the regex `%s`',
                         $part[0],
                         $part[1]
@@ -274,7 +274,7 @@ EOT;
         }
 
         // No valid route was found: list minimal required parameters
-        throw new Exception\InvalidArgumentException(sprintf(
+        throw new Exception\RuntimeException(sprintf(
             'Route `%s` expects at least parameter values for [%s], but received [%s]',
             $name,
             implode(',', $missingParameters),

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -19,9 +19,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Zend\Diactoros\ServerRequest;
-use Zend\Expressive\Router\Exception\InvalidArgumentException;
 use Zend\Expressive\Router\Exception\InvalidCacheDirectoryException;
 use Zend\Expressive\Router\Exception\InvalidCacheException;
+use Zend\Expressive\Router\Exception\RuntimeException;
 use Zend\Expressive\Router\FastRouteRouter;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
@@ -631,7 +631,7 @@ class FastRouteRouterTest extends TestCase
         $route = new Route('/foo/{id}', $this->getMiddleware(), [RequestMethod::METHOD_GET], 'foo');
         $router->addRoute($route);
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('expects at least parameter values for');
 
         $router->generateUri('foo');
@@ -641,7 +641,7 @@ class FastRouteRouterTest extends TestCase
     {
         $router = new FastRouteRouter();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('route not found');
         $router->generateUri('foo');
     }

--- a/test/UriGeneratorTest.php
+++ b/test/UriGeneratorTest.php
@@ -14,7 +14,7 @@ use FastRoute\RouteCollector;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ProphecyInterface;
 use Psr\Http\Server\MiddlewareInterface;
-use Zend\Expressive\Router\Exception\InvalidArgumentException;
+use Zend\Expressive\Router\Exception\RuntimeException;
 use Zend\Expressive\Router\FastRouteRouter;
 use Zend\Expressive\Router\Route;
 
@@ -74,7 +74,7 @@ class UriGeneratorTest extends TestCase
             [
                 '/test/{param}',
                 ['id' => 'foo'],
-                InvalidArgumentException::class,
+                RuntimeException::class,
                 'expects at least parameter values for',
             ],
 
@@ -91,7 +91,7 @@ class UriGeneratorTest extends TestCase
             [
                 '/test/{ param : \d{1,9} }',
                 ['param' => 1234567890],
-                InvalidArgumentException::class,
+                RuntimeException::class,
                 'Parameter value for [param] did not match the regex `\d{1,9}`',
             ],
 
@@ -109,7 +109,7 @@ class UriGeneratorTest extends TestCase
             [
                 '/test[/{param}[/{id:[0-9]+}]]',
                 ['param' => 'foo', 'id' => 'foo'],
-                InvalidArgumentException::class,
+                RuntimeException::class,
                 'Parameter value for [id] did not match the regex `[0-9]+`',
             ],
 


### PR DESCRIPTION
This implementation was using a different exception than the one documented in the interface, which can definitely cause problems for users following that documentation.
