### PR TITLE
Fix: Return correct FastRoute Dispatcher interface.

### DIFF
--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -11,6 +11,7 @@ namespace Zend\Expressive\Router;
 
 use FastRoute\DataGenerator\GroupCountBased as RouteGenerator;
 use FastRoute\Dispatcher\GroupCountBased as Dispatcher;
+use FastRoute\Dispatcher as DispatcherInterface;
 use FastRoute\RouteCollector;
 use FastRoute\RouteParser\Std as RouteParser;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
@@ -352,9 +353,9 @@ EOT;
      *
      * @param array|object $data Data from RouteCollection::getData()
      *
-     * @return Dispatcher
+     * @return DispatcherInterface
      */
-    private function getDispatcher($data) : Dispatcher
+    private function getDispatcher($data) : DispatcherInterface
     {
         if (! $this->dispatcherCallback) {
             $this->dispatcherCallback = $this->createDispatcherCallback();

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 namespace Zend\Expressive\Router;
 
 use FastRoute\DataGenerator\GroupCountBased as RouteGenerator;
-use FastRoute\Dispatcher\GroupCountBased as Dispatcher;
-use FastRoute\Dispatcher as DispatcherInterface;
+use FastRoute\Dispatcher\GroupCountBased;
+use FastRoute\Dispatcher;
 use FastRoute\RouteCollector;
 use FastRoute\RouteParser\Std as RouteParser;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
@@ -353,9 +353,9 @@ EOT;
      *
      * @param array|object $data Data from RouteCollection::getData()
      *
-     * @return DispatcherInterface
+     * @return Dispatcher
      */
-    private function getDispatcher($data) : DispatcherInterface
+    private function getDispatcher($data) : Dispatcher
     {
         if (! $this->dispatcherCallback) {
             $this->dispatcherCallback = $this->createDispatcherCallback();
@@ -372,7 +372,7 @@ EOT;
     private function createDispatcherCallback() : callable
     {
         return function ($data) {
-            return new Dispatcher($data);
+            return new GroupCountBased($data);
         };
     }
 

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -836,9 +836,7 @@ class FastRouteRouterTest extends TestCase
                 []
             ]);
 
-        $router = new FastRouteRouter(null, function ($data) use ($dispatcher) {
-            return $dispatcher->reveal();
-        });
+        $router = new FastRouteRouter(null, [$dispatcher, 'reveal']);
         $router->addRoute($route1);
 
         $request = new ServerRequest([], [], '/foo');

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -829,7 +829,7 @@ class FastRouteRouterTest extends TestCase
     {
         $route1 = new Route('/foo', $this->getMiddleware());
 
-        $router = new FastRouteRouter(null, function($data) {
+        $router = new FastRouteRouter(null, function ($data) {
             return new GroupPosBased($data);
         });
         $router->addRoute($route1);

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -834,13 +834,7 @@ class FastRouteRouterTest extends TestCase
         });
         $router->addRoute($route1);
 
-        $request = new ServerRequest(
-            [],
-            [],
-            '/foo',
-            RequestMethod::METHOD_GET
-        );
-
+        $request = new ServerRequest([], [], '/foo');
         $result = $router->match($request);
 
         $this->assertTrue($result->isSuccess());

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -15,6 +15,7 @@ use FastRoute\RouteCollector;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\Prophecy\ProphecyInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
@@ -825,12 +826,20 @@ class FastRouteRouterTest extends TestCase
         );
     }
 
-    public function testUserDefinedDispatcherCallbackGroupPosBased()
+    public function testCustomDispatcherCallback()
     {
         $route1 = new Route('/foo', $this->getMiddleware());
+        $dispatcher = $this->prophesize(Dispatcher::class);
+        $dispatcher->dispatch(RequestMethod::METHOD_GET, '/foo')
+            ->shouldBeCalled()
+            ->willReturn([
+                Dispatcher::FOUND,
+                '/foo',
+                []
+            ]);
 
-        $router = new FastRouteRouter(null, function ($data) {
-            return new GroupPosBased($data);
+        $router = new FastRouteRouter(null, function ($data) use ($dispatcher) {
+            return $dispatcher->reveal();
         });
         $router->addRoute($route1);
 

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -10,12 +10,10 @@ declare(strict_types=1);
 namespace ZendTest\Expressive\Router;
 
 use FastRoute\Dispatcher;
-use FastRoute\Dispatcher\GroupPosBased;
 use FastRoute\RouteCollector;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Prophecy\Prophecy\ProphecyInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace ZendTest\Expressive\Router;
 
+use FastRoute\Dispatcher\CharCountBased;
 use FastRoute\Dispatcher\GroupCountBased as Dispatcher;
+use FastRoute\Dispatcher\GroupPosBased;
 use FastRoute\RouteCollector;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use org\bovigo\vfs\vfsStream;
@@ -822,5 +824,27 @@ class FastRouteRouterTest extends TestCase
             [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST, RequestMethod::METHOD_DELETE],
             $result->getAllowedMethods()
         );
+    }
+
+    public function testUserDefinedDispatcherCallbackGroupPosBased()
+    {
+        $route1 = new Route('/foo', $this->getMiddleware());
+
+        $router = new FastRouteRouter(null, function($data) {
+            return new GroupPosBased($data);
+        });
+        $router->addRoute($route1);
+
+        $request = new ServerRequest(
+            [],
+            [],
+            '/foo',
+            RequestMethod::METHOD_GET
+        );
+
+        $result = $router->match($request);
+
+        $this->assertTrue($result->isSuccess());
+        $this->assertFalse($result->isFailure());
     }
 }

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace ZendTest\Expressive\Router;
 
-use FastRoute\Dispatcher\GroupCountBased as Dispatcher;
+use FastRoute\Dispatcher;
 use FastRoute\Dispatcher\GroupPosBased;
 use FastRoute\RouteCollector;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace ZendTest\Expressive\Router;
 
-use FastRoute\Dispatcher\CharCountBased;
 use FastRoute\Dispatcher\GroupCountBased as Dispatcher;
 use FastRoute\Dispatcher\GroupPosBased;
 use FastRoute\RouteCollector;


### PR DESCRIPTION
Currently it's impossible to define a custom FastRoute Dispatcher expect the `GroupCountBased` dispatcher. This happens because the Dispatcher interface isn't type hinted. 

Reproduce:
Define a custom callable with a different dispatcher than the `GroupCountBased`

```
$router = new FastRouteRouter(null, function ($data) {
   return new GroupPosBased($data);
});
```

Current result:

```
Return value of Zend\Expressive\Router\FastRouteRouter::getDispatcher() must be an instance of FastRoute\Dispatcher\GroupCountBased, instance of FastRoute\Dispatcher\GroupPosBased returned /usr/share/nginx/vendor/zendframework/zend-expressive-fastroute/src/FastRouteRouter.php 365
```