### PR TITLE
Fix for url encoded params.

### DIFF
--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -208,7 +208,7 @@ EOT;
 
         $dispatchData = $this->getDispatchData();
 
-        $path       = $request->getUri()->getPath();
+        $path       = rawurldecode($request->getUri()->getPath());
         $method     = $request->getMethod();
         $dispatcher = $this->getDispatcher($dispatchData);
         $result     = $dispatcher->dispatch($method, $path);


### PR DESCRIPTION
I had a problem with spaces (%20) in routes. The matched params are still url encoded after the route matching.
The path gets now url decoded (rawurldecode()) before the dispatch to FastRoute.

There could be a problem with routes which use a regex (ex. '/foo/{id:b%20r}') for url encoded special characters.