### PR TITLE
Fix uri generation for custom parser

### DIFF
--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Zend\Expressive\Router;
 
+use Closure;
 use FastRoute\DataGenerator\GroupCountBased as RouteGenerator;
 use FastRoute\Dispatcher\GroupCountBased;
 use FastRoute\Dispatcher;
@@ -188,6 +189,8 @@ EOT;
             $this->loadDispatchData();
         }
     }
+
+
 
     /**
      * Add a route to the collection.

--- a/test/FastRouterAlternativeParserTest.php
+++ b/test/FastRouterAlternativeParserTest.php
@@ -1,0 +1,58 @@
+<?php
+
+
+namespace ZendTest\Expressive\Router;
+
+
+use FastRoute\DataGenerator\GroupCountBased;
+use FastRoute\Dispatcher;
+use FastRoute\RouteCollector;
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ProphecyInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Zend\Expressive\Router\FastRouteRouter;
+use Zend\Expressive\Router\FastRouteRouterFactory;
+use Zend\Expressive\Router\Route;
+use ZendTest\Expressive\Router\Parser\CustomParser;
+
+class FastRouterAlternativeParserTest extends TestCase
+{
+
+    private function getMiddleware() : MiddlewareInterface
+    {
+        return $this->prophesize(MiddlewareInterface::class)->reveal();
+    }
+
+    public function testCustomRouteParser()
+    {
+        $sampleRoute = new Route('/custom/{id:uuid}',$this->getMiddleware(),[RequestMethod::METHOD_GET],'custom');
+        $sampleRoute->setOptions([
+            'defaults' => [
+                'id' => 'e027aa0f-1dcc-4c7b-96fc-bd401e9feb77'
+            ]
+        ]);
+
+        $router = new FastRouteRouter(
+            new RouteCollector(
+                new CustomParser(),
+                new GroupCountBased()
+            )
+        );
+
+        $router->addRoute($sampleRoute);
+
+        $uri = $router->generateUri('custom',[],['defaults' => [
+            'id' => 'e027aa0f-1dcc-4c7b-96fc-bd401e9feb77'
+        ]]);
+
+        $this->assertEquals('/custom/e027aa0f-1dcc-4c7b-96fc-bd401e9feb77',$uri);
+    }
+
+
+
+
+}

--- a/test/Parser/CustomParser.php
+++ b/test/Parser/CustomParser.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Router\Parser;
+
+use FastRoute\RouteParser\Std;
+
+use function array_keys;
+use function array_values;
+use function preg_replace;
+
+
+class CustomParser extends Std
+{
+    protected $patterns = [
+        '/{(.+?):uuid}/'          => '{$1:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}+}',
+    ];
+
+    public function parse($route) : array
+    {
+        $route = $this->replaceAliasWithRegex($route);
+        return parent::parse($route);
+    }
+
+
+    protected function replaceAliasWithRegex(string $path) : string
+    {
+        return preg_replace(array_keys($this->patterns), array_values($this->patterns), $path);
+    }
+}


### PR DESCRIPTION
Added Unit test to show difference in output between a user defined parser inside of the RouteCollector and the one generated by $router->generateUri